### PR TITLE
support gcsfuse: runArgs doesn't work for dockercompose

### DIFF
--- a/rstudio/.devcontainer.json
+++ b/rstudio/.devcontainer.json
@@ -7,7 +7,4 @@
   "workspaceFolder": "/workspace/rstudio"
   "postCreateCommand": "../post-startup.sh",
   "remoteUser": "root",
-  "runArgs": [
-    "--cap-add SYS_ADMIN", "--device /dev/fuse", "--security_opt apparmor:unconfined"
-  ]
 }

--- a/rstudio/docker-compose.yaml
+++ b/rstudio/docker-compose.yaml
@@ -12,6 +12,12 @@ services:
       "DISABLE_AUTH": "true"
     networks:
       - app-network
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
 networks:
   app-network:
     external: true


### PR DESCRIPTION
https://containers.dev/implementors/json_reference/#image-specific  runArgs is only for dockerfile or image.