### PR TITLE
BENCH-1371: Add support for user provided startup script for vertex AI notebooks

### DIFF
--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -754,7 +754,7 @@ EOF
 chown ${LOGIN_USER}:${LOGIN_USER} "${USER_BASHRC}"
 chown ${LOGIN_USER}:${LOGIN_USER} "${USER_BASH_PROFILE}"
 
-###################################
+####################################
 # Run a user provided startup script
 ####################################
 

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -36,7 +36,7 @@
 #
 # How to test changes to this file:
 #   Copy this file to a GCS bucket:
-#   - gsutil cp service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh gs://MYBUCKET
+#   - gsutil cp vertex-ai-user-managed-notebook/post-startup.sh gs://MYBUCKET
 #
 #   Create a new VM (JupyterLab provided by JupyterLab service):
 #   - terra resource create gcp-notebook \


### PR DESCRIPTION
Support an additional user supplied startup script.

Reopened from https://github.com/DataBiosphere/terra-workspace-manager/pull/1503 and addressed the comments there.

Ticket: https://verily.atlassian.net/browse/BENCH-1371

