### PR TITLE
BENCH-1515: start workbench app proxy agent as a separete systemd unit

### DIFF
--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -768,7 +768,7 @@ if [[ -n "${APP_PROXY}" ]]; then
   NEW_PROXY_URL="${RESOURCE_ID}.${APP_PROXY}"
 
   # Create a systemd service to start the workbench app proxy.
-  cat << EOF >"${WORKBENCH_PROXY_AGENT_SERVICE}"
+  cat << EOF > "${WORKBENCH_PROXY_AGENT_SERVICE}"
 [Unit]
 Description=Workbench App Proxy Agent Service
 StartLimitIntervalSec=600


### PR DESCRIPTION
https://verily.atlassian.net/browse/BENCH-1515

on reboot, the `rc-local.service` will overwrite proxy.env again because `attempt-register-vm-on-proxy.sh` is added to /etc/rc.local. [attempt-register-vm-on-proxy.sh](https://source.corp.google.com/piper///depot/google3/cloud/ml/dset/dlenv/build/vm/packer/clean/files/c2d/scripts/01-attempt-register-vm-on-proxy.sh;l=24)