### PR TITLE
[BENCH-1639] Separate exit_status init from previous command

### DIFF
--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -366,8 +366,9 @@ readonly TERRA_SERVER
 # If the server environment is a verily server, use the verily download script.
 if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
   # Map the CLI server to appropriate AFS service path and fetch the CLI distribution path
-  versionJson="$(curl -s "https://${TERRA_SERVER/verily/terra}-axon.api.verily.com/version")" || exit_code=$?
-  if [[ "${exit_code}" -ne 0 ]]; then
+  versionJson="$(curl -s "https://${TERRA_SERVER/verily/terra}-axon.api.verily.com/version")"
+  exit_status=$?
+  if [[ "${exit_status}" -ne 0 ]]; then
       >&2 echo "ERROR: ${TERRA_SERVER} is not a known server"
       exit 1
   fi

--- a/startupscript/post-startup.sh
+++ b/startupscript/post-startup.sh
@@ -118,8 +118,9 @@ readonly TERRA_SERVER
 # If the server environment is a verily server, use the verily download script.
 if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
   # Map the CLI server to appropriate AFS service path and fetch the CLI distribution path
-  versionJson="$(curl -s "https://${TERRA_SERVER/verily/terra}-axon.api.verily.com/version")" || exit_code=$?
-  if [[ "${exit_code}" -ne 0 ]]; then
+  versionJson="$(curl -s "https://${TERRA_SERVER/verily/terra}-axon.api.verily.com/version")"
+  exit_status=$?
+  if [[ "${exit_status}" -ne 0 ]]; then
       >&2 echo "ERROR: ${TERRA_SERVER} is not a known server"
       exit 1
   fi

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -402,8 +402,9 @@ readonly TERRA_SERVER
 # If the server environment is a verily server, use the verily download script.
 if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
   # Map the CLI server to appropriate AFS service path and fetch the CLI distribution path
-  versionJson="$(curl -s "https://${TERRA_SERVER/verily/terra}-axon.api.verily.com/version")" || exit_code=$?
-  if [[ "${exit_code}" -ne 0 ]]; then
+  versionJson="$(curl -s "https://${TERRA_SERVER/verily/terra}-axon.api.verily.com/version")"
+  exit_status=$?
+  if [[ "${exit_status}" -ne 0 ]]; then
       >&2 echo "ERROR: ${TERRA_SERVER} is not a known server"
       exit 1
   fi


### PR DESCRIPTION
RC - variable exit_code was being set only in the context of the previous statement, and hence not accessible in the subsequent if block
fix - init the exist_status variable in a new line so that it is accessible in rest of code flow