### PR TITLE
[BENCH-1947] Fix dataproc startup script

### DIFF
--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -230,6 +230,19 @@ ${RUN_AS_LOGIN_USER} "touch '${USER_BASHRC}'"
 
 emit "Resynchronizing apt package index..."
 
+#########################################
+# Add missing gpg keys for apt-get update
+#########################################
+# The dataproc debian images installs mysql-tools from https://repo.mysql.com/apt/debian.
+
+# Retrieve latest key ID for mysql
+readonly MYSQL_KEY="$(curl -s https://repo.mysql.com/apt/debian/conf/distributions | grep -A 4 'Codename: bullseye' | grep 'SignWith' | awk '{print $2}')"
+# Retrieve the gpg key
+gpg --keyserver keyserver.ubuntu.com --recv-keys "${MYSQL_KEY}"
+# Add the key to the trusted list
+readonly MYSQL_KEY_PATH="/etc/apt/trusted.gpg.d/mysql.gpg"
+gpg --export "${MYSQL_KEY}" | sudo tee "${MYSQL_KEY_PATH}" >/dev/null
+
 # The apt package index may not be clean when we run; resynchronize
 apt-get update
 

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -233,8 +233,8 @@ emit "Resynchronizing apt package index..."
 #########################################
 # Add missing gpg keys for apt-get update
 #########################################
-# The dataproc debian images installs mysql-tools from https://repo.mysql.com/apt/debian.
 
+# The dataproc debian images installs mysql-tools from https://repo.mysql.com/apt/debian.
 # Retrieve latest key ID for mysql
 readonly MYSQL_KEY="$(curl -s https://repo.mysql.com/apt/debian/conf/distributions | grep -A 4 'Codename: bullseye' | grep 'SignWith' | awk '{print $2}')"
 # Retrieve the gpg key
@@ -243,8 +243,9 @@ gpg --keyserver keyserver.ubuntu.com --recv-keys "${MYSQL_KEY}"
 readonly MYSQL_KEY_PATH="/etc/apt/trusted.gpg.d/mysql.gpg"
 gpg --export "${MYSQL_KEY}" | sudo tee "${MYSQL_KEY_PATH}" >/dev/null
 
-# The apt package index may not be clean when we run; resynchronize
-apt-get update
+# The apt package index may not be clean when we run; resynchronize.
+# Prevent errors when a repo changes its metadata.
+apt-get update --allow-releaseinfo-change
 
 # Create the target directories for installing into the HOME directory
 ${RUN_AS_LOGIN_USER} "mkdir -p '${USER_BASH_COMPLETION_DIR}'"


### PR DESCRIPTION
A few issues came up with starting up dataproc clusters overnight.

Two errors appeared during the `apt-get install` line.
1. mysql repo key is missing
2. gcp repo updated its some labels in its release info.

This PR addresses both issues.

More details on the errors here: https://verily.atlassian.net/browse/BENCH-1947