### PR TITLE
BENCH-1769: Install latest version of R in dataproc startup script

### DIFF
--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -49,7 +49,8 @@ readonly OUTPUT_FILE="${USER_WORKBENCH_CONFIG_DIR}/install-r-output.txt"
 
 readonly CONDA_DIR='/opt/conda/miniconda3'
 readonly CONDA_BIN_DIR="${CONDA_DIR}/bin"
-readonly R_BIN_DIR='/usr/lib/R/bin'
+readonly R_HOME_DIR='/usr/lib/R'
+readonly R_BIN_DIR="${R_HOME_DIR}/bin"
 readonly RUN_R="${R_BIN_DIR}/R"
 
 # Split stdout and stderr in the rest of this script to an output file for debugging.
@@ -101,7 +102,7 @@ if [[ "${DATAPROC_NODE_ROLE}" == 'Master' ]]; then
   cat <<EOF >"${IR_KERNEL}"
 {
   "argv": [
-    "/usr/lib/R/bin/R",
+    "${RUN_R}",
     "--slave",
     "-e",
     "IRkernel::main()",
@@ -111,7 +112,7 @@ if [[ "${DATAPROC_NODE_ROLE}" == 'Master' ]]; then
   "display_name": "R",
   "language": "R",
   "env": {
-    "R_HOME": "/usr/lib/R",
+    "R_HOME": "${R_HOME_DIR}",
     "SPARK_HOME": "/usr/lib/spark"
   }
 }

--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -6,33 +6,60 @@
 # This script is intended to be executed as a Dataproc cluster initialization
 # action so such that R is installed and configured on all cluster nodes during
 # creation and autoscaling.
+#
+# This action depends on some user home directory directories being created.
+# Depending on the cluster node type, these directories may not exist. The workbench
+# startup script
+
 # For more information on Initialization actions, see:
 # https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/init-actions
 
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
+# Configure shell
+set -o errexit  # Exit on error
+set -o nounset  # Treat unset variables as error
+set -o pipefail # Surface errors inside pipelines
+set -o xtrace   # Output commands before executing them
 
-# Emit a message with a timestamp
+# Utility function to emit a message with a timestamp
 function emit() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') $*"
 }
 readonly -f emit
 
-# Define directories and system files
-readonly LOGIN_USER="dataproc"
+# The linux user that JupyterLab will be running as
+readonly LOGIN_USER='dataproc'
+
+# Create an alias for cases when we need to run a shell command as the login user.
+# Note that we deliberately use "bash -l" instead of "sh" in order to get bash (instead of dash)
+# and to pick up changes to the .bashrc.
+#
+# This is intentionally not a Bash function, as that can suppress error propagation.
+# This is intentionally not a Bash alias as they are not supported in shell scripts.
+readonly RUN_AS_LOGIN_USER="sudo -u ${LOGIN_USER} bash -l -c"
+
+# Define directories and paths to binaries and system file
 readonly USER_HOME_DIR="/home/${LOGIN_USER}"
 readonly USER_WORKBENCH_CONFIG_DIR="${USER_HOME_DIR}/.workbench"
 readonly USER_BASHRC="${USER_HOME_DIR}/.bashrc"
-readonly R_BIN_DIR='/usr/lib/R/bin'
+
 readonly OUTPUT_FILE="${USER_WORKBENCH_CONFIG_DIR}/install-r-output.txt"
 
-# Send stdout and stderr from this script to a file for debugging.
-exec >>"${OUTPUT_FILE}"
+readonly CONDA_BIN_DIR='/opt/conda/miniconda3/bin'
+readonly R_BIN_DIR='/usr/lib/R/bin'
+readonly RUN_R="${R_BIN_DIR}/R"
+
+# Split stdout and stderr in the rest of this script to an output file for debugging.
+# But still output to stdout and stderr so users can also debug via the initialization
+# action output files in the cluster staging bucket.
+exec > >(tee -a "${OUTPUT_FILE}") 2>&1
 exec 2>&1
 
 emit "Installing R ..."
+
+# Ensure that the user's workbench configuration directory exists
+mkdir -p "${USER_WORKBENCH_CONFIG_DIR}"
+${RUN_AS_LOGIN_USER} "mkdir -p '${USER_WORKBENCH_CONFIG_DIR}'"
+
 # Add CRAN R archive network repository
 add-apt-repository "deb https://cloud.r-project.org/bin/linux/debian $(lsb_release -cs)-cran40/"
 
@@ -47,6 +74,14 @@ gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' |
 # Install r-base package
 apt-get update -y
 apt-get install r-base -y
+
+# Install IRKernel to support interactive R notebooks in Jupyter
+# Note: We set the PATH to ensure that R knows were to find the 'jupyter' binary
+# See IR kernel installation docs:
+# https://irkernel.github.io/installation/
+PATH="${CONDA_BIN_DIR}:${PATH}" "${RUN_R}" -e "\
+install.packages('IRkernel', repos='http://cran.rstudio.com/');
+IRkernel::installspec()"
 
 # Add R to the PATH in user's bashrc
 cat <<EOF >>"${USER_BASHRC}"

--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -13,6 +13,9 @@
 #
 # For more information on Initialization actions, see:
 # https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/init-actions
+#
+# NOTE: This script is hosted and served from the Workbench scripts Google storage bucket.
+# https://storage.googleapis.com/workbench_scripts/install-r.sh
 
 # Configure shell
 set -o errexit  # Exit on error

--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# install-r.sh
+# Installs the latest version of R
+#
+# This script is intended to be executed as a Dataproc cluster initialization
+# action so such that R is installed and configured on all cluster nodes during
+# creation and autoscaling.
+# For more information on Initialization actions, see:
+# https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/init-actions
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Emit a message with a timestamp
+function emit() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $*"
+}
+readonly -f emit
+
+# Define directories and system files
+readonly LOGIN_USER="dataproc"
+readonly USER_HOME_DIR="/home/${LOGIN_USER}"
+readonly USER_WORKBENCH_CONFIG_DIR="${USER_HOME_DIR}/.workbench"
+readonly USER_BASHRC="${USER_HOME_DIR}/.bashrc"
+readonly R_BIN_DIR='/usr/lib/R/bin'
+readonly OUTPUT_FILE="${USER_WORKBENCH_CONFIG_DIR}/install-r-output.txt"
+
+# Send stdout and stderr from this script to a file for debugging.
+# Make the .wb directory as the user so that they own it and have correct linux permissions.
+exec >>"${OUTPUT_FILE}"
+exec 2>&1
+
+emit "Installing R ..."
+# Add CRAN R archive network repository
+add-apt-repository "deb https://cloud.r-project.org/bin/linux/debian $(lsb_release -cs)-cran40/"
+
+# Fetch and export the repository's gpg key
+# See debian package installation instructions:
+# https://cran.r-project.org/bin/linux/debian/
+gpg --keyserver keyserver.ubuntu.com \
+  --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
+gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' |
+  sudo tee /etc/apt/trusted.gpg.d/cran_debian_key.asc
+
+# Install r-base package
+apt-get update -y
+apt-get install r-base -y
+
+# Add R to the PATH in user's bashrc
+cat <<EOF >>"${USER_BASHRC}"
+# Prepend "${R_BIN_DIR}" (if not already in the path)
+if [[ ":\${PATH}:" != *":${R_BIN_DIR}:"* ]]; then
+  export PATH="${R_BIN_DIR}":"\${PATH}"
+fi
+EOF

--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -30,7 +30,7 @@ function emit() {
 readonly -f emit
 
 # Retrieve and set the dataproc node type
-readonly DATAPROC_NODE_ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+readonly DATAPROC_NODE_ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 
 # The linux user that JupyterLab will be running as
 readonly LOGIN_USER='dataproc'
@@ -52,9 +52,13 @@ readonly OUTPUT_FILE="${USER_WORKBENCH_CONFIG_DIR}/install-r-output.txt"
 
 readonly CONDA_DIR='/opt/conda/miniconda3'
 readonly CONDA_BIN_DIR="${CONDA_DIR}/bin"
+
 readonly R_HOME_DIR='/usr/lib/R'
 readonly R_BIN_DIR="${R_HOME_DIR}/bin"
 readonly RUN_R="${R_BIN_DIR}/R"
+
+readonly IR_KERNEL="${CONDA_DIR}/share/jupyter/kernels/ir/kernel.json"
+readonly JUPYTER_SERVICE_NAME='jupyter.service'
 
 # Split stdout and stderr in the rest of this script to an output file for debugging.
 # But still output to stdout and stderr so users can also debug via the initialization
@@ -101,7 +105,6 @@ if [[ "${DATAPROC_NODE_ROLE}" == 'Master' ]]; then
   IRkernel::installspec()"
 
   # Point IR jupyter kernel to the newly installed R
-  readonly IR_KERNEL="${CONDA_DIR}/share/jupyter/kernels/ir/kernel.json"
   cat <<EOF >"${IR_KERNEL}"
 {
   "argv": [
@@ -122,6 +125,5 @@ if [[ "${DATAPROC_NODE_ROLE}" == 'Master' ]]; then
 EOF
 
   # Restart jupyter service to pick up the new R kernel
-  readonly JUPYTER_SERVICE_NAME='jupyter.service'
   systemctl restart "${JUPYTER_SERVICE_NAME}"
 fi

--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # install-r.sh
 # Installs the latest version of R
 #
@@ -28,7 +29,6 @@ readonly R_BIN_DIR='/usr/lib/R/bin'
 readonly OUTPUT_FILE="${USER_WORKBENCH_CONFIG_DIR}/install-r-output.txt"
 
 # Send stdout and stderr from this script to a file for debugging.
-# Make the .wb directory as the user so that they own it and have correct linux permissions.
 exec >>"${OUTPUT_FILE}"
 exec 2>&1
 


### PR DESCRIPTION
Adds an initialization action to install the latest version of R on all dataproc cluster nodes. See https://verily.atlassian.net/browse/BENCH-1769 for more details.

For the short term, we need to put this script in our public gcs bucket as initialization scripts only supports public gcs files, so we can't use a github file url.

Followup work: Modify WSM to pass this script as an initialization action on cluster creation.