### PR TITLE
Add shellcheck step to PR workflow.

### DIFF
--- a/.github/actions/smoke-test/build.sh
+++ b/.github/actions/smoke-test/build.sh
@@ -22,10 +22,12 @@ cp -R "src/${TEMPLATE_ID}" "${SRC_DIR}"
 pushd "${SRC_DIR}"
 
 # Configure templates only if `devcontainer-template.json` contains the `options` property.
-readonly OPTION_PROPERTY="$(jq -r '.options' devcontainer-template.json)"
+OPTION_PROPERTY="$(jq -r '.options' devcontainer-template.json)"
+readonly OPTION_PROPERTY
 
 if [[ "${OPTION_PROPERTY}" != "" ]] && [[ "${OPTION_PROPERTY}" != "null" ]]; then  
-    readonly OPTIONS=( $(jq -r '.options | keys[]' devcontainer-template.json) )
+    OPTIONS="( $(jq -r '.options | keys[]' devcontainer-template.json) )"
+    readonly OPTIONS
 
     if [[ "${OPTIONS[0]}" != "" ]] && [[ "${OPTIONS[0]}" != "null" ]]; then
         echo "(!) Configuring template options for '${TEMPLATE_ID}'"
@@ -75,4 +77,4 @@ docker network create -d bridge app-network
 ################################################
 echo "Building Dev Container"
 readonly ID_LABEL="test-container=${TEMPLATE_ID}"
-devcontainer up --id-label ${ID_LABEL} --workspace-folder "${SRC_DIR}"
+devcontainer up --id-label "${ID_LABEL}" --workspace-folder "${SRC_DIR}"

--- a/.github/actions/smoke-test/build.sh
+++ b/.github/actions/smoke-test/build.sh
@@ -26,7 +26,7 @@ OPTION_PROPERTY="$(jq -r '.options' devcontainer-template.json)"
 readonly OPTION_PROPERTY
 
 if [[ "${OPTION_PROPERTY}" != "" ]] && [[ "${OPTION_PROPERTY}" != "null" ]]; then  
-    OPTIONS="( $(jq -r '.options | keys[]' devcontainer-template.json) )"
+    OPTIONS=( "$(jq -r '.options | keys[]' devcontainer-template.json)" )
     readonly OPTIONS
 
     if [[ "${OPTIONS[0]}" != "" ]] && [[ "${OPTIONS[0]}" != "null" ]]; then

--- a/.github/actions/smoke-test/build.sh
+++ b/.github/actions/smoke-test/build.sh
@@ -25,8 +25,8 @@ pushd "${SRC_DIR}"
 OPTION_PROPERTY="$(jq -r '.options' devcontainer-template.json)"
 readonly OPTION_PROPERTY
 
-if [[ "${OPTION_PROPERTY}" != "" ]] && [[ "${OPTION_PROPERTY}" != "null" ]]; then  
-    OPTIONS=( "$(jq -r '.options | keys[]' devcontainer-template.json)" )
+if [[ "${OPTION_PROPERTY}" != "" ]] && [[ "${OPTION_PROPERTY}" != "null" ]]; then
+    IFS=" " read -r -a OPTIONS <<< "$(jq -r '.options | keys[]' devcontainer-template.json)"
     readonly OPTIONS
 
     if [[ "${OPTIONS[0]}" != "" ]] && [[ "${OPTIONS[0]}" != "null" ]]; then

--- a/.github/actions/smoke-test/test.sh
+++ b/.github/actions/smoke-test/test.sh
@@ -14,6 +14,9 @@ readonly SRC_DIR="/tmp/${TEMPLATE_ID}"
 echo "Running Smoke Test"
 
 readonly ID_LABEL="test-container=${TEMPLATE_ID}"
+
+# Suppressed expansion is intentional
+# shellcheck disable=SC2016
 devcontainer exec \
   --workspace-folder "${SRC_DIR}" \
   --id-label "${ID_LABEL}" \

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -3,6 +3,16 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          check_together: 'yes'
+        env:
+          SHELLCHECK_OPTS: -e SC1090 -e SC1091
+
   detect-changes:
     runs-on: ubuntu-latest
     outputs:

--- a/startupscript/README.md
+++ b/startupscript/README.md
@@ -87,7 +87,7 @@ these cases the variable should be marked `readonly` as a subsequent step.  This
 `shellcheck` rule [SC2155](https://www.shellcheck.net/wiki/SC2155).
 
 ```shell
-FOO=$(command)
+FOO="$(command)"
 readonly FOO
 ```
 

--- a/startupscript/README.md
+++ b/startupscript/README.md
@@ -66,12 +66,19 @@ Clone this repo and put it in a public repo you own. Make the change
 
 Shell code in this repo will be checked with `shellcheck` as part of pull request testing.
 
+The `shellcheck` tool [can be installed locally](https://github.com/koalaman/shellcheck?tab=readme-ov-file#installing).
+Additionally, VSCode has a [ShellCheck extension](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck).
+
 To configure `shellcheck` locally with the same configuration as the PR lint tasks, create a
 `~/.shellcheckrc` file with the following content:
 
 ```shell
 disable=SC1090,SC1091
 ```
+
+This disables checks [SC1090](https://www.shellcheck.net/wiki/SC1090) and
+[SC1091](https://www.shellcheck.net/wiki/SC1091), to work around limitations in
+`shellcheck` around dynamic file handling.
 
 In addition to `shellcheck`-enforced logic, it is highly recommended that variables and functions
 be made `readonly` to prevent overriding or unsetting.

--- a/startupscript/README.md
+++ b/startupscript/README.md
@@ -82,7 +82,7 @@ For trivial variable assignment this can be done on a single line:
 readonly FOO="foo"
 ```
 
-However, for assingments that involve calling a command, `readonly` can mask error responses; in
+However, for assignments that involve calling a command, `readonly` can mask error responses; in
 these cases the variable should be marked `readonly` as a subsequent step.  This is enforced by
 `shellcheck` rule [SC2155](https://www.shellcheck.net/wiki/SC2155).
 

--- a/startupscript/README.md
+++ b/startupscript/README.md
@@ -26,7 +26,7 @@ Make your change and push to a branch.
 
 - Step 2
 
-```
+```text
 wb resource create gcp-notebook --id=jupyterNotebookForTesting --post-startup-script=https://raw.githubusercontent.com/verily-src/workbench-app-devcontainers/<your-branch>/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
 ```
 
@@ -41,7 +41,7 @@ Make your change and push to a branch.
 
 - Step 2
 
-```
+```text
 wb resource create dataproc-cluster --name=dataprocForTesting --metadata=startup-script-url=https://raw.githubusercontent.com/verily-src/workbench-app-devcontainers/<your-branch>/startupscript/dataproc/startup.sh
 ```
 
@@ -62,9 +62,47 @@ Clone this repo and put it in a public repo you own. Make the change
 - Step 3
   Wait for the notebook to spin up and go to the instance. Check .workbench/post-startup-output.txt to see if it succeeds.
 
+## Linting and Style
+
+Shell code in this repo will be checked with `shellcheck` as part of pull request testing.
+
+To configure `shellcheck` locally with the same configuration as the PR lint tasks, create a
+`~/.shellcheckrc` file with the following content:
+
+```shell
+disable=SC1090,SC1091
+```
+
+In addition to `shellcheck`-enforced logic, it is highly recommended that variables and functions
+be made `readonly` to prevent overriding or unsetting.
+
+For trivial variable assignment this can be done on a single line:
+
+```shell
+readonly FOO="foo"
+```
+
+However, for assingments that involve calling a command, `readonly` can mask error responses; in
+these cases the variable should be marked `readonly` as a subsequent step.  This is enforced by
+`shellcheck` rule [SC2155](https://www.shellcheck.net/wiki/SC2155).
+
+```shell
+FOO=$(command)
+readonly FOO
+```
+
+Functions follow this syntax:
+
+```shell
+function my_function {
+    # ... function logic ...
+}
+readonly -f my_func
+```
+
 ## General debugging tips
 
-- Check /home/<user>/.workbench/post-startup-output.txt to see where the script failed.
+- Check /home/**\<user\>**/.workbench/post-startup-output.txt to see where the script failed.
   The user is jupyter for vertex AI, dataproc for dataproc cluster, and varies by app for gce instance.
 
 - If the proxy url doesn't work, you can ssh to the VM.

--- a/startupscript/dataproc/install-r.sh
+++ b/startupscript/dataproc/install-r.sh
@@ -30,7 +30,8 @@ function emit() {
 readonly -f emit
 
 # Retrieve and set the dataproc node type
-readonly DATAPROC_NODE_ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+DATAPROC_NODE_ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+readonly DATAPROC_NODE_ROLE
 
 # The linux user that JupyterLab will be running as
 readonly LOGIN_USER='dataproc'

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -45,7 +45,7 @@ set -o pipefail
 set -o xtrace
 
 # Only run on the dataproc manager node. Exit silently if otherwise.
-ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 if [[ "${ROLE}" != 'Master' ]]; then exit 0; fi
 readonly ROLE
 
@@ -289,6 +289,7 @@ if ! which gcsfuse >/dev/null 2>&1; then
   # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
   GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
   readonly GCSFUSE_REPO
+
   echo "deb https://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" | tee /etc/apt/sources.list.d/gcsfuse.list
   curl "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
   apt-get update \

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -173,9 +173,11 @@ readonly -f emit
 function get_metadata_value() {
   local metadata_path="${1}"
   curl --retry 5 -s -f \
-    -H "Metadata-Flavor: Google" \
-    "http://metadata/computeMetadata/v1/${metadata_path}"
+      -H "Metadata-Flavor: Google" \
+      "http://metadata/computeMetadata/v1/${metadata_path}" \
+    || echo -n
 }
+readonly -f get_metadata_value
 
 #######################################
 # Set guest attributes on GCE. Used here to log completion status of the script.

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -286,6 +286,7 @@ if ! which gcsfuse >/dev/null 2>&1; then
 
   # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
   GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
+  readonly GCSFUSE_REPO
   echo "deb https://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" | tee /etc/apt/sources.list.d/gcsfuse.list
   curl "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
   apt-get update \
@@ -386,7 +387,7 @@ if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
     >&2 echo "ERROR: Failed to get version file from ${TERRA_SERVER}"
     exit 1
   fi
-  cliDistributionPath="$(echo ${versionJson} | jq -r '.cliDistributionPath')"
+  cliDistributionPath="$(echo "${versionJson}" | jq -r '.cliDistributionPath')"
 
   ${RUN_AS_LOGIN_USER} "curl -L https://storage.googleapis.com/${cliDistributionPath#gs://}/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash"
   cp wb "${WORKBENCH_INSTALL_PATH}"
@@ -802,7 +803,8 @@ EOF
 # If the script executer has set the "software-framework" property to "HAIL",
 # then install Hail after Dataproc optional components are installed.
 
-readonly SOFTWARE_FRAMEWORK="$(get_metadata_value "instance/attributes/software-framework")"
+SOFTWARE_FRAMEWORK="$(get_metadata_value "instance/attributes/software-framework")"
+readonly SOFTWARE_FRAMEWORK
 
 if [[ "${SOFTWARE_FRAMEWORK}" == "HAIL" ]]; then
   emit "Installing Hail..."
@@ -1066,7 +1068,8 @@ systemctl daemon-reload
 emit "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
 
 # Get the current major version of Java: "11.0.12" => "11"
-readonly INSTALLED_JAVA_VERSION="$(${RUN_AS_LOGIN_USER} "${JAVA_INSTALL_PATH} -version" 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+INSTALLED_JAVA_VERSION="$(${RUN_AS_LOGIN_USER} "${JAVA_INSTALL_PATH} -version" 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+readonly INSTALLED_JAVA_VERSION
 if [[ "${INSTALLED_JAVA_VERSION}" -lt "${REQ_JAVA_VERSION}" ]]; then
   >&2 emit "ERROR: Java version detected (${INSTALLED_JAVA_VERSION}) is less than required (${REQ_JAVA_VERSION})"
   exit 1
@@ -1077,14 +1080,16 @@ emit "SUCCESS: Java installed and version detected as ${INSTALLED_JAVA_VERSION}"
 # Test nextflow
 emit "--  Checking if Nextflow is properly installed"
 
-readonly INSTALLED_NEXTFLOW_VERSION="$(${RUN_AS_LOGIN_USER} "${NEXTFLOW_INSTALL_PATH} -v" | sed -e 's#nextflow version \(.*\)#\1#')"
+INSTALLED_NEXTFLOW_VERSION="$(${RUN_AS_LOGIN_USER} "${NEXTFLOW_INSTALL_PATH} -v" | sed -e 's#nextflow version \(.*\)#\1#')"
+readonly INSTALLED_NEXTFLOW_VERSION
 
 emit "SUCCESS: Nextflow installed and version detected as ${INSTALLED_NEXTFLOW_VERSION}"
 
 # Test Cromwell
 emit "--  Checking if installed Cromwell version is ${CROMWELL_LATEST_VERSION}"
 
-readonly INSTALLED_CROMWELL_VERSION="$(${RUN_AS_LOGIN_USER} "java -jar ${CROMWELL_INSTALL_JAR} --version" | sed -e 's#cromwell \(.*\)#\1#')"
+INSTALLED_CROMWELL_VERSION="$(${RUN_AS_LOGIN_USER} "java -jar ${CROMWELL_INSTALL_JAR} --version" | sed -e 's#cromwell \(.*\)#\1#')"
+readonly INSTALLED_CROMWELL_VERSION
 if [[ "${INSTALLED_CROMWELL_VERSION}" -ne ${CROMWELL_LATEST_VERSION} ]]; then
   >&2 emit "ERROR: Cromwell version detected (${INSTALLED_CROMWELL_VERSION}) is not equal to expected (${CROMWELL_LATEST_VERSION})"
   exit 1
@@ -1114,7 +1119,8 @@ if [[ ! -e "${WORKBENCH_INSTALL_PATH}" ]]; then
   exit 1
 fi
 
-readonly INSTALLED_WORKBENCH_VERSION="$(${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} version")"
+INSTALLED_WORKBENCH_VERSION="$(${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} version")"
+readonly INSTALLED_WORKBENCH_VERSION
 
 if [[ -z "${INSTALLED_WORKBENCH_VERSION}" ]]; then
   >&2 emit "ERROR: Workbench CLI did not execute or did not return a version number"
@@ -1145,7 +1151,8 @@ if [[ ! -e "${USER_SSH_DIR}" ]]; then
   >&2 emit "ERROR: user SSH directory does not exist"
   exit 1
 fi
-readonly SSH_DIR_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}")"
+SSH_DIR_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}")"
+readonly SSH_DIR_MODE
 if [[ "${SSH_DIR_MODE}" != "700 dataproc dataproc" ]]; then
   >&2 emit "ERROR: user SSH directory permissions are incorrect: ${SSH_DIR_MODE}"
   exit 1
@@ -1154,7 +1161,8 @@ fi
 # If the user didn't have an SSH key configured, then the id_rsa file won't exist.
 # If they do have the file, check the permissions
 if [[ -e "${USER_SSH_DIR}/id_rsa" ]]; then
-  readonly SSH_KEY_FILE_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}/id_rsa")"
+  SSH_KEY_FILE_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}/id_rsa")"
+  readonly SSH_KEY_FILE_MODE
   if [[ "${SSH_KEY_FILE_MODE}" != "600 dataproc dataproc" ]]; then
     >&2 emit "ERROR: user SSH key file permissions are incorrect: ${SSH_DIR_MODE}/id_rsa"
     exit 1
@@ -1164,7 +1172,8 @@ fi
 # GIT_IGNORE
 emit "--  Checking if gitignore is properly installed"
 
-readonly INSTALLED_GITIGNORE="$(${RUN_AS_LOGIN_USER} "git config --global core.excludesfile")"
+INSTALLED_GITIGNORE="$(${RUN_AS_LOGIN_USER} "git config --global core.excludesfile")"
+readonly INSTALLED_GITIGNORE
 
 if [[ "${INSTALLED_GITIGNORE}" != "${GIT_IGNORE}" ]]; then
   >&2 emit "ERROR: gitignore not set up at ${GIT_IGNORE}"

--- a/startupscript/gcp/resource-mount.sh
+++ b/startupscript/gcp/resource-mount.sh
@@ -19,7 +19,8 @@ if ! which gcsfuse >/dev/null 2>&1; then
     lsb-release
 
   # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
-  readonly GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
+  GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
+  readonly GCSFUSE_REPO
   echo "deb https://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" > /etc/apt/sources.list.d/gcsfuse.list
   curl "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
   apt-get update \

--- a/startupscript/gcp/resource-mount.sh
+++ b/startupscript/gcp/resource-mount.sh
@@ -21,6 +21,7 @@ if ! which gcsfuse >/dev/null 2>&1; then
   # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
   GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
   readonly GCSFUSE_REPO
+
   echo "deb https://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" > /etc/apt/sources.list.d/gcsfuse.list
   curl "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
   apt-get update \

--- a/startupscript/git-setup.sh
+++ b/startupscript/git-setup.sh
@@ -12,13 +12,15 @@
 # - emit (function)
 # - Workbench CLI is installed
 # - git is installed in the image or as a devcontainer feature (ghcr.io/devcontainers/features/git:1)
-# - USER_SSH_DIR: path to ssh directory (~/.ssh)
+# - WORK_DIRECTORY: home directory for the user that the script is running on behalf of
 # - WORKBENCH_GIT_REPOS_DIR: path to the git repo directory (~/repos)
 # - RUN_AS_LOGIN_USER: run command as app user
 
 emit "Setting up git integration..."
 
 # Create the user SSH directory
+readonly USER_SSH_DIR="${WORK_DIRECTORY}/.ssh"
+readonly WORKBENCH_GIT_REPOS_DIR="${WORK_DIRECTORY}/repos"
 ${RUN_AS_LOGIN_USER} "mkdir -p ${USER_SSH_DIR} --mode 0700"
 
 # Get the user's SSH key from Workbench, and if set, write it to the user's .ssh directory

--- a/startupscript/install-cli.sh
+++ b/startupscript/install-cli.sh
@@ -32,7 +32,7 @@ if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
     >&2 echo "ERROR: Failed to get version file from ${TERRA_SERVER}"
     exit 1
   fi
-  cliDistributionPath="$(echo ${versionJson} | jq -r '.cliDistributionPath')"
+  cliDistributionPath="$(echo "${versionJson}" | jq -r '.cliDistributionPath')"
 
   ${RUN_AS_LOGIN_USER} "curl -L https://storage.googleapis.com/${cliDistributionPath#gs://}/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash"
   cp wb "${WORKBENCH_INSTALL_PATH}"
@@ -61,7 +61,8 @@ if [[ "${LOG_IN}" == "true" ]]; then
   ${RUN_AS_LOGIN_USER} "wb auth login --mode=APP_DEFAULT_CREDENTIALS"
 
   # Set the CLI workspace id using the VM metadata, if set.
-  readonly TERRA_WORKSPACE="$(get_metadata_value "terra-workspace-id")"
+  TERRA_WORKSPACE="$(get_metadata_value "terra-workspace-id")"
+  readonly TERRA_WORKSPACE
   if [[ -n "${TERRA_WORKSPACE}" ]]; then
     ${RUN_AS_LOGIN_USER} "wb workspace set --id='${TERRA_WORKSPACE}'"
   fi

--- a/startupscript/post-startup.sh
+++ b/startupscript/post-startup.sh
@@ -18,13 +18,14 @@ readonly LOG_IN="${4}"
 # Gets absolute path of the script directory. 
 # Because the script sometimes cd to other directoy (e.g. /tmp), 
 # absolute path is more reliable.
-readonly SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+readonly SCRIPT_DIR
 #######################################
 # Emit a message with a timestamp
 #######################################
-source ${SCRIPT_DIR}/emit.sh
+source "${SCRIPT_DIR}/emit.sh"
 
-source ${SCRIPT_DIR}/${CLOUD}/vm-metadata.sh
+source "${SCRIPT_DIR}/${CLOUD}/vm-metadata.sh"
 
 readonly RUN_AS_LOGIN_USER="sudo -u ${USER_NAME} bash -l -c"
 
@@ -32,18 +33,14 @@ readonly USER_BASH_COMPLETION_DIR="${WORK_DIRECTORY}/.bash_completion.d"
 readonly USER_HOME_LOCAL_SHARE="${WORK_DIRECTORY}/.local/share"
 readonly USER_WORKBENCH_CONFIG_DIR="${WORK_DIRECTORY}/.workbench"
 readonly USER_WORKBENCH_LEGACY_CONFIG_DIR="${WORK_DIRECTORY}/.terra"
-readonly USER_SSH_DIR="${WORK_DIRECTORY}/.ssh"
 readonly USER_BASHRC="${WORK_DIRECTORY}/.bashrc"
 readonly USER_BASH_PROFILE="${WORK_DIRECTORY}/.bash_profile"
 readonly POST_STARTUP_OUTPUT_FILE="${USER_WORKBENCH_CONFIG_DIR}/post-startup-output.txt"
 
-readonly JAVA_INSTALL_TMP="${USER_WORKBENCH_CONFIG_DIR}/javatmp"
-
 # Variables for Workbench-specific code installed on the VM
 readonly WORKBENCH_INSTALL_PATH="/usr/bin/wb"
 readonly WORKBENCH_LEGACY_PATH="/usr/bin/terra"
-
-readonly WORKBENCH_GIT_REPOS_DIR="${WORK_DIRECTORY}/repos"
+export WORKBENCH_INSTALL_PATH WORKBENCH_LEGACY_PATH
 
 # Move to the /tmp directory to let any artifacts left behind by this script can be removed.
 cd /tmp || exit
@@ -85,7 +82,7 @@ EOF
 ##################################################
 # Set up java which is required for workbench CLI 
 ##################################################
-source ${SCRIPT_DIR}/install-java.sh
+source "${SCRIPT_DIR}/install-java.sh"
 
 ###################################
 # Install workbench CLI
@@ -100,16 +97,16 @@ source "${SCRIPT_DIR}/setup-bashrc.sh"
 #################
 # bash completion
 #################
-source ${SCRIPT_DIR}/bash-completion.sh
+source "${SCRIPT_DIR}/bash-completion.sh"
 
 ###############
 # git setup
 ###############
 if [[ "${LOG_IN}" == "true" ]]; then
-    source ${SCRIPT_DIR}/git-setup.sh
+    source "${SCRIPT_DIR}/git-setup.sh"
 fi
 
 #############################
 # Mount buckets
 #############################
-source ${SCRIPT_DIR}/${CLOUD}/resource-mount.sh
+source "${SCRIPT_DIR}/${CLOUD}/resource-mount.sh"

--- a/startupscript/setup-bashrc.sh
+++ b/startupscript/setup-bashrc.sh
@@ -25,15 +25,17 @@ emit "Customize user bashrc ..."
 
 if [[ "${LOG_IN}" == "true" ]]; then
   # OWNER_EMAIL is really the Workbench user account email address
-  readonly OWNER_EMAIL="$(
+  OWNER_EMAIL="$(
     ${RUN_AS_LOGIN_USER} "wb workspace describe --format=json" | \
     jq --raw-output ".userEmail")"
+  readonly OWNER_EMAIL
 
   # PET_SA_EMAIL is the pet service account for the Workbench user and
   # is specific to the GCP project backing the workspace
-  readonly PET_SA_EMAIL="$(
+  PET_SA_EMAIL="$(
     ${RUN_AS_LOGIN_USER} "wb auth status --format=json" | \
     jq --raw-output ".serviceAccountEmail")"
+  readonly PET_SA_EMAIL
 
   cat << EOF >> "${USER_BASHRC}"
 # Set up a few legacy Workbench-specific convenience variables
@@ -53,9 +55,10 @@ fi
 if [[ "${CLOUD}" == "gcp" && "${LOG_IN}" == "true" ]]; then
 
   # GOOGLE_PROJECT is the project id for the GCP project backing the workspace
-  readonly GOOGLE_PROJECT="$(
+  GOOGLE_PROJECT="$(
     ${RUN_AS_LOGIN_USER} "wb workspace describe --format=json" | \
     jq --raw-output ".googleProjectId")"
+  readonly GOOGLE_PROJECT
   
   emit "Adding Workbench GCP-sepcific environment variables to ~/.bashrc ..."
 

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -222,7 +222,7 @@ set_guest_attributes "${STATUS_ATTRIBUTE}" "STARTED"
 
 emit "Determining JupyterLab environment (jupyter.service or docker)"
 
-INSTANCE_CONTAINER="$(get_metadata_value "instance/attributes/container")"
+INSTANCE_CONTAINER="$(get_metadata_value instance/attributes/container)"
 readonly INSTANCE_CONTAINER
 if [[ -n "${INSTANCE_CONTAINER}" ]]; then
   emit "Custom container for JupyterLab detected: ${INSTANCE_CONTAINER}."

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -180,6 +180,7 @@ function get_metadata_value() {
       "http://metadata/computeMetadata/v1/$1" \
     || echo -n
 }
+readonly -f get_metadata_value
 
 #######################################
 # Set guest attributes on GCE. Used here to log completion status of the script.
@@ -195,6 +196,7 @@ function set_guest_attributes() {
     -H "Metadata-Flavor: Google" \
     "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/${attr_path}"
 }
+readonly -f set_guest_attributes
 
 # If the script exits without error let the UI know it completed successfully
 # Otherwise if an error occurred write the line and command that failed to guest attributes.
@@ -212,6 +214,7 @@ function exit_handler {
   set_guest_attributes "${MESSAGE_ATTRIBUTE}" "Error on line ${line_no}, command \"${command}\". See ${POST_STARTUP_OUTPUT_FILE} for more information."
   exit "${exit_code}"
 }
+readonly -f exit_handler
 trap 'exit_handler $? $LINENO $BASH_COMMAND' EXIT
 
 #######################################

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -222,7 +222,8 @@ set_guest_attributes "${STATUS_ATTRIBUTE}" "STARTED"
 
 emit "Determining JupyterLab environment (jupyter.service or docker)"
 
-readonly INSTANCE_CONTAINER="$(get_metadata_value "instance/attributes/container")"
+INSTANCE_CONTAINER="$(get_metadata_value "instance/attributes/container")"
+readonly INSTANCE_CONTAINER
 if [[ -n "${INSTANCE_CONTAINER}" ]]; then
   emit "Custom container for JupyterLab detected: ${INSTANCE_CONTAINER}."
   # When JupyterLab is provided by a Docker container, the default Deep Learning images
@@ -415,7 +416,7 @@ if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
     >&2 echo "ERROR: Failed to get version file from ${TERRA_SERVER}"
     exit 1
   fi
-  cliDistributionPath="$(echo ${versionJson} | jq -r '.cliDistributionPath')"
+  cliDistributionPath="$(echo "${versionJson}" | jq -r '.cliDistributionPath')"
 
   ${RUN_AS_LOGIN_USER} "curl -L https://storage.googleapis.com/${cliDistributionPath#gs://}/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash"
   cp wb "${WORKBENCH_INSTALL_PATH}"
@@ -445,7 +446,8 @@ ${RUN_AS_LOGIN_USER} "wb generate-completion > '${USER_BASH_COMPLETION_DIR}/work
 ####################################
 
 # Set the CLI workspace id using the VM metadata, if set.
-readonly TERRA_WORKSPACE="$(get_metadata_value "instance/attributes/terra-workspace-id")"
+TERRA_WORKSPACE="$(get_metadata_value "instance/attributes/terra-workspace-id")"
+readonly TERRA_WORKSPACE
 if [[ -n "${TERRA_WORKSPACE}" ]]; then
   ${RUN_AS_LOGIN_USER} "wb workspace set --id='${TERRA_WORKSPACE}'"
 fi
@@ -466,20 +468,23 @@ fi
 # (https://github.com/DataBiosphere/leonardo)
 
 # OWNER_EMAIL is really the Workbench user account email address
-readonly OWNER_EMAIL="$(
+OWNER_EMAIL="$(
   ${RUN_AS_LOGIN_USER} "wb workspace describe --format=json" | \
   jq --raw-output ".userEmail")"
+readonly OWNER_EMAIL
 
 # GOOGLE_PROJECT is the project id for the GCP project backing the workspace
-readonly GOOGLE_PROJECT="$(
+GOOGLE_PROJECT="$(
   ${RUN_AS_LOGIN_USER} "wb workspace describe --format=json" | \
   jq --raw-output ".googleProjectId")"
+readonly GOOGLE_PROJECT
 
 # PET_SA_EMAIL is the pet service account for the Workbench user and
 # is specific to the GCP project backing the workspace
-readonly PET_SA_EMAIL="$(
+PET_SA_EMAIL="$(
   ${RUN_AS_LOGIN_USER} "wb auth status --format=json" | \
   jq --raw-output ".serviceAccountEmail")"
+readonly PET_SA_EMAIL
 
 # These are equivalent environment variables which are set for a
 # command when calling "wb app execute <command>".
@@ -765,7 +770,8 @@ chown ${LOGIN_USER}:${LOGIN_USER} "${USER_BASH_PROFILE}"
 # If the user has provided a startup script, run it after workbench setup but
 # before restarting Jupyter and running tests.
 
-readonly USER_STARTUP_SCRIPT="$(get_metadata_value "instance/attributes/terra-user-startup-script")"
+USER_STARTUP_SCRIPT="$(get_metadata_value "instance/attributes/terra-user-startup-script")"
+readonly USER_STARTUP_SCRIPT
 if [[ -n "${USER_STARTUP_SCRIPT}" ]]; then
   readonly USER_STARTUP_SCRIPT_FILE="${USER_WORKBENCH_CONFIG_DIR}/user-startup-script.sh"
 
@@ -788,8 +794,10 @@ fi
 ######################################
 # Restart proxy to pick up the new env
 ######################################
-readonly APP_PROXY=$(get_metadata_value "instance/attributes/terra-app-proxy")
-readonly TERRA_GCP_NOTEBOOK_RESOURCE_NAME="$(get_metadata_value "instance/attributes/terra-gcp-notebook-resource-name")"
+APP_PROXY=$(get_metadata_value "instance/attributes/terra-app-proxy")
+readonly APP_PROXY
+TERRA_GCP_NOTEBOOK_RESOURCE_NAME="$(get_metadata_value "instance/attributes/terra-gcp-notebook-resource-name")"
+readonly TERRA_GCP_NOTEBOOK_RESOURCE_NAME
 if [[ -n "${APP_PROXY}" ]]; then
   emit "Using custom Proxy Agent"
   RESOURCE_ID=$(get_metadata_value "instance/attributes/terra-resource-id")
@@ -853,7 +861,8 @@ fi
 emit "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
 
 # Get the current major version of Java: "11.0.12" => "11"
-readonly INSTALLED_JAVA_VERSION="$(${RUN_AS_LOGIN_USER} "${JAVA_INSTALL_PATH} -version" 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+INSTALLED_JAVA_VERSION="$(${RUN_AS_LOGIN_USER} "${JAVA_INSTALL_PATH} -version" 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+readonly INSTALLED_JAVA_VERSION
 if [[ "${INSTALLED_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]]; then
   >&2 emit "ERROR: Java version detected (${INSTALLED_JAVA_VERSION}) is less than required (${REQ_JAVA_VERSION})"
   exit 1
@@ -864,14 +873,16 @@ emit "SUCCESS: Java installed and version detected as ${INSTALLED_JAVA_VERSION}"
 # Test nextflow
 emit "--  Checking if Nextflow is properly installed"
 
-readonly INSTALLED_NEXTFLOW_VERSION="$(${RUN_AS_LOGIN_USER} "${NEXTFLOW_INSTALL_PATH} -v" | sed -e 's#nextflow version \(.*\)#\1#')"
+INSTALLED_NEXTFLOW_VERSION="$(${RUN_AS_LOGIN_USER} "${NEXTFLOW_INSTALL_PATH} -v" | sed -e 's#nextflow version \(.*\)#\1#')"
+readonly INSTALLED_NEXTFLOW_VERSION
 
 emit "SUCCESS: Nextflow installed and version detected as ${INSTALLED_NEXTFLOW_VERSION}"
 
 # Test Cromwell
 emit "--  Checking if installed Cromwell version is ${CROMWELL_LATEST_VERSION}"
 
-readonly INSTALLED_CROMWELL_VERSION="$(${RUN_AS_LOGIN_USER} "java -jar ${CROMWELL_INSTALL_JAR} --version" | sed -e 's#cromwell \(.*\)#\1#')"
+INSTALLED_CROMWELL_VERSION="$(${RUN_AS_LOGIN_USER} "java -jar ${CROMWELL_INSTALL_JAR} --version" | sed -e 's#cromwell \(.*\)#\1#')"
+readonly INSTALLED_CROMWELL_VERSION
 if [[ "${INSTALLED_CROMWELL_VERSION}" -ne ${CROMWELL_LATEST_VERSION} ]]; then
   >&2 emit "ERROR: Cromwell version detected (${INSTALLED_CROMWELL_VERSION}) is not equal to expected (${CROMWELL_LATEST_VERSION})"
   exit 1
@@ -901,7 +912,8 @@ if [[ ! -e "${WORKBENCH_INSTALL_PATH}" ]]; then
   exit 1
 fi
 
-readonly INSTALLED_WORKBENCH_VERSION="$(${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} version")"
+INSTALLED_WORKBENCH_VERSION="$(${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} version")"
+readonly INSTALLED_WORKBENCH_VERSION
 
 if [[ -z "${INSTALLED_WORKBENCH_VERSION}" ]]; then
   >&2 emit "ERROR: Workbench CLI did not execute or did not return a version number"
@@ -917,7 +929,8 @@ if [[ ! -e "${USER_SSH_DIR}" ]]; then
   >&2 emit "ERROR: user SSH directory does not exist"
   exit 1
 fi
-readonly SSH_DIR_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}")"
+SSH_DIR_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}")"
+readonly SSH_DIR_MODE
 if [[ "${SSH_DIR_MODE}" != "700 jupyter jupyter" ]]; then
   >&2 emit "ERROR: user SSH directory permissions are incorrect: ${SSH_DIR_MODE}"
   exit 1
@@ -926,7 +939,8 @@ fi
 # If the user didn't have an SSH key configured, then the id_rsa file won't exist.
 # If they do have the file, check the permissions
 if [[ -e "${USER_SSH_DIR}/id_rsa" ]]; then
-  readonly SSH_KEY_FILE_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}/id_rsa")"
+  SSH_KEY_FILE_MODE="$(stat -c "%a %G %U" "${USER_SSH_DIR}/id_rsa")"
+  readonly SSH_KEY_FILE_MODE
   if [[ "${SSH_KEY_FILE_MODE}" != "600 jupyter jupyter" ]]; then
     >&2 emit "ERROR: user SSH key file permissions are incorrect: ${SSH_DIR_MODE}/id_rsa"
     exit 1
@@ -937,7 +951,8 @@ fi
 # GIT_IGNORE
 emit "--  Checking if gitignore is properly installed"
 
-readonly INSTALLED_GITIGNORE="$(${RUN_AS_LOGIN_USER} "git config --global core.excludesfile")"
+INSTALLED_GITIGNORE="$(${RUN_AS_LOGIN_USER} "git config --global core.excludesfile")"
+readonly INSTALLED_GITIGNORE
 
 if [[ "${INSTALLED_GITIGNORE}" != "${GIT_IGNORE}" ]]; then
   >&2 emit "ERROR: gitignore not set up at ${GIT_IGNORE}"
@@ -948,7 +963,8 @@ emit "SUCCESS: Gitignore installed at ${INSTALLED_GITIGNORE}"
 
 # This block is for test only. If the notebook execute successfully down to
 # here, we knows that the script executed successfully.
-readonly WORKBENCH_TEST_VALUE="$(get_metadata_value "instance/attributes/terra-test-value")"
+WORKBENCH_TEST_VALUE="$(get_metadata_value "instance/attributes/terra-test-value")"
+readonly WORKBENCH_TEST_VALUE
 if [[ -n "${WORKBENCH_TEST_VALUE}" ]]; then
   ${RUN_AS_LOGIN_USER} "wb resource update gcp-notebook --name=${TERRA_GCP_NOTEBOOK_RESOURCE_NAME} --new-metadata=terra-test-result=${WORKBENCH_TEST_VALUE}"
 fi

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -176,8 +176,9 @@ readonly -f emit
 #######################################
 function get_metadata_value() {
   curl --retry 5 -s -f \
-    -H "Metadata-Flavor: Google" \
-    "http://metadata/computeMetadata/v1/$1"
+      -H "Metadata-Flavor: Google" \
+      "http://metadata/computeMetadata/v1/$1" \
+    || echo -n
 }
 
 #######################################
@@ -222,7 +223,7 @@ set_guest_attributes "${STATUS_ATTRIBUTE}" "STARTED"
 
 emit "Determining JupyterLab environment (jupyter.service or docker)"
 
-INSTANCE_CONTAINER="$(get_metadata_value instance/attributes/container)"
+INSTANCE_CONTAINER="$(get_metadata_value "instance/attributes/container")"
 readonly INSTANCE_CONTAINER
 if [[ -n "${INSTANCE_CONTAINER}" ]]; then
   emit "Custom container for JupyterLab detected: ${INSTANCE_CONTAINER}."

--- a/test/test-utils/test-utils.sh
+++ b/test/test-utils/test-utils.sh
@@ -24,7 +24,7 @@ readonly -f check
 
 function reportResults() {
     if [[ ${#FAILED[@]} -ne 0 ]]; then
-        echoStderr -e "\n💥  Failed tests: ${FAILED[@]}"
+        echoStderr -e "\n💥  Failed tests: " "${FAILED[@]}"
         exit 1
     else 
         echo -e "\n💯  All passed!"

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
+cd "$(dirname "$0")" || exit
 source test-utils.sh
 
 # Template specific tests


### PR DESCRIPTION
Enables PR check to lint shell scripts with `shellcheck`.  Script changes are needed to get a clean linter run.

These changes have been tested with AI Notebook, Dataproc Cluster, and custom apps.