### PR TITLE
fix jq syntax error

### DIFF
--- a/src/cirrocumulus/scripts/cirro_scanner.sh
+++ b/src/cirrocumulus/scripts/cirro_scanner.sh
@@ -12,7 +12,7 @@ set -o pipefail
 function matching_dataset_count() {
     local url="$1"
     curl -s localhost:3000/api/datasets | \
-        jq -e --arg path "${url}" '.[] | select(.url == ${path})' | \
+        jq -e --arg path "${url}" '.[] | select(.url == $path)' | \
         wc -l
 }
 readonly -f matching_dataset_count


### PR DESCRIPTION
jq: error: syntax error, unexpected '{', expecting IDENT or __loc__ (Unix shell quoting issues?) at <top-level>, line 1: .[] | select(.url == ${path})                       jq: 1 compile error