### PR TITLE
Enable Building Workbench Java Code in VS Code

### DIFF
--- a/src/cirrocumulus/.devcontainer.json
+++ b/src/cirrocumulus/.devcontainer.json
@@ -9,6 +9,7 @@
   "postStartCommand": "nohup bash -c '[[ ${templateOption:login} == true ]] && ./scripts/cirro_scanner.sh &'",
   "features": {
       "ghcr.io/devcontainers/features/aws-cli:1": {},
+      "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
       "ghcr.io/devcontainers/features/java:1": {}
   },
   "remoteUser": "root"

--- a/src/jupyter/.devcontainer.json
+++ b/src/jupyter/.devcontainer.json
@@ -9,6 +9,7 @@
   "postStartCommand": "/bin/bash -c '[[ \"${templateOption:login}\" == \"true\" ]] && sudo -u jovyan wb resource mount || true'",
   "features": {
         "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
         "ghcr.io/devcontainers/features/java:1": {} 
    },
   "remoteUser": "root"

--- a/src/rstudio/.devcontainer.json
+++ b/src/rstudio/.devcontainer.json
@@ -13,6 +13,7 @@
         	"installSystemRequirements": true
         },
         "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
         "ghcr.io/devcontainers/features/java:1": {} 
    },
   "remoteUser": "root"

--- a/src/shiny/.devcontainer.json
+++ b/src/shiny/.devcontainer.json
@@ -11,6 +11,7 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},
     "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
     "ghcr.io/devcontainers/features/java:1": {} 
   },
   "appPort": [

--- a/src/vscode/.devcontainer.json
+++ b/src/vscode/.devcontainer.json
@@ -8,8 +8,12 @@
   // re-mount bucket files on container start up
   "postStartCommand": "/bin/bash -c '[[ \"${templateOption:login}\" == \"true\" ]] && sudo -u abc wb resource mount || true'",
   "features": {
-        "ghcr.io/devcontainers/features/java:1": {},
-        "ghcr.io/devcontainers/features/aws-cli:1": {}
+        "ghcr.io/devcontainers/features/java:1": {
+          "version": "17"
+        },
+        "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/dhoeric/features/google-cloud-cli:1": {}
+
   },
   "remoteUser": "root"
 }

--- a/src/vscode/.devcontainer.json
+++ b/src/vscode/.devcontainer.json
@@ -13,7 +13,6 @@
         },
         "ghcr.io/devcontainers/features/aws-cli:1": {},
         "ghcr.io/dhoeric/features/google-cloud-cli:1": {}
-
   },
   "remoteUser": "root"
 }


### PR DESCRIPTION
I'm not sure what the intent of our vscode app is, but these changes are necessary to be able to build Workbench Java code in the app (lock to Java 17, `gcloud`needed for private artifacts), which I have found very useful for testing in-EC2 behavior.