### PR TITLE
[BENCH-2574] Using IMDSv2 in all requests to get the EC2 instance id

### DIFF
--- a/src/idlechecker/idle-checker.sh
+++ b/src/idlechecker/idle-checker.sh
@@ -35,8 +35,10 @@ readonly -f set_guest_attributes
 
 function create_tag() {
   emit "Creating tag vwbapp:${LAST_ACTIVE_KEY}"
+  local imds_token
+  imds_token=$(wget --method=PUT --header "X-aws-ec2-metadata-token-ttl-seconds:600" -q -O - http://169.254.169.254/latest/api/token)
   local id
-  id="$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)"
+  id=$(wget --header "X-aws-ec2-metadata-token: $imds_token" -q -O - http://169.254.169.254/latest/meta-data/instance-id)
   aws ec2 create-tags \
     --resources "${id}" \
     --tags Key=vwbapp:${LAST_ACTIVE_KEY},Value="$1"

--- a/startupscript/aws/vm-metadata.sh
+++ b/startupscript/aws/vm-metadata.sh
@@ -16,7 +16,8 @@ function get_metadata_value() {
   fi
   local tag_key=vwbapp:"$1"
 
-  INSTANCE_ID="$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)"
+  IMDS_TOKEN=$(wget --method=PUT --header "X-aws-ec2-metadata-token-ttl-seconds:600" -q -O - http://169.254.169.254/latest/api/token)
+  INSTANCE_ID=$(wget --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" -q -O - http://169.254.169.254/latest/meta-data/instance-id)
   aws ec2 describe-tags \
     --filters "Name=resource-id,Values=${INSTANCE_ID}" "Name=key,Values=$tag_key" \
     --query "Tags[0].Value" --output text 2>/dev/null


### PR DESCRIPTION
Migrating EC2 instances to use IMDSv2. This needs to be released at the same time as the update to EC2 instance creation, which raises the PUT hop limit to 2 (https://github.com/verily-src/terra-service-ws-manager/pull/856).

DO NOT MERGE YET

[BENCH-2574](https://verily.atlassian.net/browse/BENCH-2574)