### PR TITLE
[BENCH-855] Allow users to toggle display of hidden files in jupyter browser

### DIFF
--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -1078,6 +1078,9 @@ a#workspace {\
 
 ### BEGIN: Workbench-specific customizations ###
 
+# Allow users to toggle display of hidden files in file browser
+c.ContentsManager.allow_hidden = True
+
 EOF
 
   # Remove the default GCSContentsManager and set jupyter file tree's root directory to the LOGIN_USER's home directory.

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -322,6 +322,9 @@ cat << EOF >> "${NOTEBOOK_CONFIG}"
 
 ### BEGIN: Workbench-specific customizations ###
 
+# Allow users to toggle display of hidden files in file browser
+c.ContentsManager.allow_hidden = True
+
 EOF
 
 # Update the PATH for container JupyterLab


### PR DESCRIPTION
This change allows users to toggle whether hidden files (prefixed with `.`) are shown in the Jupyter file browser or not. By enabling this setting, Jupyter adds a "Show hidden files" option under the `View` menu. By default this is off, which matches previous behavior.

I've added this for all notebooks and dataproc clusters (including ones via custom image) as this option was [added in Jupyterlab 3.2.0](https://github.com/jupyterlab/jupyterlab/issues/2049)(early 2022). My assumption is that users are not using significantly older versions of Jupyterlab - please let me know if that's not true and I can avoid setting it for custom images.