### PR TITLE
AWS Startup Script Fixes

### DIFF
--- a/startupscript/aws/bashrc-functions.bash
+++ b/startupscript/aws/bashrc-functions.bash
@@ -4,7 +4,7 @@
 # kept separate so that these functions can be linted with shellcheck.
 
 function configure_workspace() {
-  "${WORKBENCH_INSTALL_PATH}" workspace set --uuid "${WORKBENCH_WORKSPACE}"
+  "${WORKBENCH_INSTALL_PATH}" workspace set --uuid "${WORKBENCH_WORKSPACE_UUID}"
   "${WORKBENCH_INSTALL_PATH}" workspace configure-aws --cache-with-aws-vault=true
   "${WORKBENCH_INSTALL_PATH}" resource mount
 }

--- a/startupscript/aws/post-startup-hook.sh
+++ b/startupscript/aws/post-startup-hook.sh
@@ -41,15 +41,15 @@ ${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set aws-vault-path --path
 #################################################
 # Write common environment vars to user's .bashrc
 #################################################
-WORKBENCH_WORKSPACE="$(get_metadata_value terra-workspace-id)"
-readonly WORKBENCH_WORKSPACE
-AWS_CONFIG_FILE="${USER_WORKBENCH_CONFIG_DIR}/aws/${WORKBENCH_WORKSPACE}.conf"
+WORKBENCH_WORKSPACE_UUID="$(get_metadata_value_raw WorkspaceId)"
+readonly WORKBENCH_WORKSPACE_UUID
+AWS_CONFIG_FILE="${USER_WORKBENCH_CONFIG_DIR}/aws/${WORKBENCH_WORKSPACE_UUID}.conf"
 readonly AWS_CONFIG_FILE
 
 cat > "${USER_BASHRC}" << EOF
 
 # AWS-specific Workbench Configuration Environment Variables
-export WORKBENCH_WORKSPACE="${WORKBENCH_WORKSPACE}"
+export WORKBENCH_WORKSPACE_UUID="${WORKBENCH_WORKSPACE_UUID}"
 export WORKBENCH_GIT_REPOS_DIR="${WORK_DIRECTORY}/repos"
 export WORKBENCH_INSTALL_PATH="${WORKBENCH_INSTALL_PATH}"
 export AWS_CONFIG_FILE="${AWS_CONFIG_FILE}"

--- a/startupscript/aws/post-startup-hook.sh
+++ b/startupscript/aws/post-startup-hook.sh
@@ -41,7 +41,7 @@ ${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set aws-vault-path --path
 #################################################
 # Write common environment vars to user's .bashrc
 #################################################
-WORKBENCH_WORKSPACE_UUID="$(get_metadata_value_raw WorkspaceId)"
+WORKBENCH_WORKSPACE_UUID="$(get_metadata_value_unprefixed WorkspaceId)"
 readonly WORKBENCH_WORKSPACE_UUID
 AWS_CONFIG_FILE="${USER_WORKBENCH_CONFIG_DIR}/aws/${WORKBENCH_WORKSPACE_UUID}.conf"
 readonly AWS_CONFIG_FILE

--- a/startupscript/aws/vm-metadata.sh
+++ b/startupscript/aws/vm-metadata.sh
@@ -2,27 +2,37 @@
 
 # vm-metadata.sh
 #
-# Defines a function to retrieve an instance tag set on the VM.
+# Defines functions to retrieve an instance tag set on the VM.
 #
 # Note that this script is intended to be sourced from the "post-startup.sh" script
 # and is dependent on some functions and packages already installed.
 #
 # - aws (cli from ghcr.io/devcontainers/features/aws-cli:1) 
 
-function get_metadata_value() {
-  if [[ -z "$1" ]]; then
-    echo "usage: get_metadata_value <tag>"
+function get_metadata_value_raw() {
+    if [[ -z "$1" ]]; then
+    echo "usage: get_metadata_value_raw <tag>"
     exit 1
   fi
-  local tag_key=vwbusr:"$1"
 
   local imds_token
   imds_token="$(wget --method=PUT --header "X-aws-ec2-metadata-token-ttl-seconds:600" -q -O - http://169.254.169.254/latest/api/token)"
   local instance_id
   instance_id="$(wget --header "X-aws-ec2-metadata-token: ${imds_token}" -q -O - http://169.254.169.254/latest/meta-data/instance-id)"
   aws ec2 describe-tags \
-    --filters "Name=resource-id,Values=${instance_id}" "Name=key,Values=${tag_key}" \
+    --filters "Name=resource-id,Values=${instance_id}" "Name=key,Values=$1" \
     --query "Tags[0].Value" --output text 2>/dev/null
+}
+readonly -f get_metadata_value_raw
+
+function get_metadata_value() {
+  if [[ -z "$1" ]]; then
+    echo "usage: get_metadata_value <tag>"
+    exit 1
+  fi
+
+  local tag_key=vwbusr:"$1"
+  get_metadata_value_raw "${tag_key}"
 }
 readonly -f get_metadata_value 
 

--- a/startupscript/aws/vm-metadata.sh
+++ b/startupscript/aws/vm-metadata.sh
@@ -9,9 +9,15 @@
 #
 # - aws (cli from ghcr.io/devcontainers/features/aws-cli:1) 
 
-function get_metadata_value_raw() {
-    if [[ -z "$1" ]]; then
-    echo "usage: get_metadata_value_raw <tag>"
+# The get_metadata_value function is used to query for tags prefixed with "vwbusr:" attached to the
+# running istance.  Tags intended for use in startup script have this prefix.  However, we have a
+# temporary need to query the value of the "WorkspaceId" tag while we wait for the "no login"
+# authentication mechanism for AWS to get released in all environments.  Writing get_metadata_value
+# in terms of get_metadata_value_unprefixed is done for code reuse; this should be collapsed back
+# down into a single get_metadata_value function once this is no longer needed.
+function get_metadata_value_unprefixed() {
+  if [[ -z "$1" ]]; then
+    echo "usage: get_metadata_value_unprefixed <tag>"
     exit 1
   fi
 
@@ -23,7 +29,7 @@ function get_metadata_value_raw() {
     --filters "Name=resource-id,Values=${instance_id}" "Name=key,Values=$1" \
     --query "Tags[0].Value" --output text 2>/dev/null
 }
-readonly -f get_metadata_value_raw
+readonly -f get_metadata_value_unprefixed
 
 function get_metadata_value() {
   if [[ -z "$1" ]]; then
@@ -32,7 +38,7 @@ function get_metadata_value() {
   fi
 
   local tag_key=vwbusr:"$1"
-  get_metadata_value_raw "${tag_key}"
+  get_metadata_value_unprefixed "${tag_key}"
 }
 readonly -f get_metadata_value 
 

--- a/startupscript/aws/vm-metadata.sh
+++ b/startupscript/aws/vm-metadata.sh
@@ -14,7 +14,7 @@ function get_metadata_value() {
     echo "usage: get_metadata_value <tag>"
     exit 1
   fi
-  local tag_key=vwbapp:"$1"
+  local tag_key=vwbusr:"$1"
 
   local imds_token
   imds_token="$(wget --method=PUT --header "X-aws-ec2-metadata-token-ttl-seconds:600" -q -O - http://169.254.169.254/latest/api/token)"


### PR DESCRIPTION
Makes the following changes:
- Fixes wrong tag prefix in AWS startup script `get_metadata_value` function (`s/vwbapp/vwbuser`).
- Uses `WorkspaceId` tag for "no-login" path, as this will always be present, and always be set to the Workspace UUID.  Renamed variables `s/WORKBENCH_WORKSPACE/WORKBENCH_WORKSPACE_UUID` to make this explicit.

Note that the "no-login" paths will be removed once the AWS AuthNZ is released to all environments.  So this is a workaround to prevent having to phase in the WSM fix to use user-facing ID for the `vwbusr:terra-workspace-id` tag.