### PR TITLE
Enable non-interactive login path for AWS.

### DIFF
--- a/startupscript/aws/configure-aws-vault.sh
+++ b/startupscript/aws/configure-aws-vault.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -x
+
+# configure-aws-vault.sh
+#
+# Performs additional one-time configuration for applications running in AWS
+# EC2 instances.
+#
+# Note that this script is intended to be sourced from the "post-startup.sh"
+# script and is dependent on some functions and variables already being set up
+# and some packages already installed:
+#
+# - emit (function)
+# - RUN_AS_LOGIN_USER: run command as app user
+# - WORKBENCH_INSTALL_PATH: path to CLI executable
+
+readonly AWS_VAULT_INSTALL_PATH="/usr/bin/aws-vault"
+readonly AWS_VAULT_EXE_URL="https://github.com/99designs/aws-vault/releases/download/v7.2.0/aws-vault-linux-amd64"
+
+if [[ -f "${AWS_VAULT_INSTALL_PATH}" ]]; then
+    emit "aws-vault already installed"
+    exit 0
+fi
+
+##########################################
+# Install aws-vault for credential caching
+##########################################
+emit "installing aws-vault"
+curl --no-progress-meter --location --output "${AWS_VAULT_INSTALL_PATH}" "${AWS_VAULT_EXE_URL}"
+chmod 755 "${AWS_VAULT_INSTALL_PATH}"
+
+##########################################
+# Export AWS-related environment variables
+##########################################
+export AWS_VAULT_BACKEND="file"
+export AWS_VAULT_FILE_PASSPHRASE=""
+
+#####################################
+# Set up aws-vault credential caching
+#####################################
+${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set cache-with-aws-vault true"
+${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set wb-path --path ${WORKBENCH_INSTALL_PATH}"
+${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set aws-vault-path --path ${AWS_VAULT_INSTALL_PATH}"

--- a/startupscript/aws/post-startup-hook.sh
+++ b/startupscript/aws/post-startup-hook.sh
@@ -12,7 +12,6 @@
 # - aws (cli from ghcr.io/devcontainers/features/aws-cli:1)
 # - emit (function)
 # - CLOUD_SCRIPT_DIR: path where AWS-specific scripts live
-# - RUN_AS_LOGIN_USER: run command as app user
 # - USER_BASH_PROFILE: path to user's ~/.bash_profile file
 # - USER_BASHRC: path to user's ~/.bashrc file
 # - USER_NAME: name of app user
@@ -21,22 +20,15 @@
 # - WORK_DIRECTORY: home directory for the user that the script is running on behalf of
 # - WORKBENCH_INSTALL_PATH: path to CLI executable
 
-readonly AWS_VAULT_INSTALL_PATH="/usr/bin/aws-vault"
-readonly AWS_VAULT_EXE_URL="https://github.com/99designs/aws-vault/releases/download/v7.2.0/aws-vault-linux-amd64"
+if [[ "${LOG_IN}" == "true" ]]; then
+    emit "Already logged in, skipping additional AWS configuration."
+    exit 0
+fi
 
-##########################################
-# Install aws-vault for credential caching
-##########################################
-emit "installing aws-vault"
-curl --no-progress-meter --location --output "${AWS_VAULT_INSTALL_PATH}" "${AWS_VAULT_EXE_URL}"
-chmod 755 "${AWS_VAULT_INSTALL_PATH}"
-
-#####################################
-# Set up aws-vault credential caching
-#####################################
-${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set cache-with-aws-vault true"
-${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set wb-path --path ${WORKBENCH_INSTALL_PATH}"
-${RUN_AS_LOGIN_USER} "${WORKBENCH_INSTALL_PATH} config set aws-vault-path --path ${AWS_VAULT_INSTALL_PATH}"
+########################################################
+# Install and configure aws-vault for credential caching
+########################################################
+source "${CLOUD_SCRIPT_DIR}/configure-aws-vault.sh"
 
 #################################################
 # Write common environment vars to user's .bashrc

--- a/startupscript/aws/resource-mount.sh
+++ b/startupscript/aws/resource-mount.sh
@@ -9,6 +9,7 @@
 # and is dependent on some functions and variables already being set up and some packages already installed:
 #
 # - emit (function)
+# - CLOUD_SCRIPT_DIR: path where AWS-specific scripts live
 # - LOG_IN: whether the user is logged into workbench CLI
 # - RUN_AS_LOGIN_USER: run command as user
 
@@ -25,5 +26,9 @@ else
 fi
 
 if [[ "${LOG_IN}" == "true" ]]; then
-  ${RUN_AS_LOGIN_USER} "wb resource mount"
+  source "${CLOUD_SCRIPT_DIR}/configure-aws-vault.sh"
+  ${RUN_AS_LOGIN_USER} "export AWS_VAULT_BACKEND='file' && \
+    export AWS_VAULT_FILE_PASSPHRASE='' && \
+    eval  \$(wb workspace configure-aws) && \
+    wb resource mount"
 fi

--- a/startupscript/aws/resource-mount.sh
+++ b/startupscript/aws/resource-mount.sh
@@ -27,5 +27,8 @@ fi
 
 if [[ "${LOG_IN}" == "true" ]]; then
   source "${CLOUD_SCRIPT_DIR}/configure-aws-vault.sh"
-  ${RUN_AS_LOGIN_USER} "source ${HOME}/.bashrc && wb resource mount"
+  ${RUN_AS_LOGIN_USER} "export AWS_VAULT_BACKEND='file' && \
+    export AWS_VAULT_FILE_PASSPHRASE='' && \
+    eval  \$(wb workspace configure-aws) && \
+    wb resource mount"
 fi

--- a/startupscript/aws/resource-mount.sh
+++ b/startupscript/aws/resource-mount.sh
@@ -27,8 +27,5 @@ fi
 
 if [[ "${LOG_IN}" == "true" ]]; then
   source "${CLOUD_SCRIPT_DIR}/configure-aws-vault.sh"
-  ${RUN_AS_LOGIN_USER} "export AWS_VAULT_BACKEND='file' && \
-    export AWS_VAULT_FILE_PASSPHRASE='' && \
-    eval  \$(wb workspace configure-aws) && \
-    wb resource mount"
+  ${RUN_AS_LOGIN_USER} "source ${HOME}/.bashrc && wb resource mount"
 fi

--- a/startupscript/git-setup.sh
+++ b/startupscript/git-setup.sh
@@ -50,7 +50,9 @@ ${RUN_AS_LOGIN_USER} "mkdir -p '${WORKBENCH_GIT_REPOS_DIR}'"
 # This loop replaces the logic of "wb git clone --all", which currently does not work without
 # Google Application Default Credentials being available.  This emulates the behavior of the CLI
 # command, continuing with an error message when an individual repo cannot be cloned.
-pushd "${WORKBENCH_GIT_REPOS_DIR}" || exit
+
+# shellcheck disable=SC2164
+pushd "${WORKBENCH_GIT_REPOS_DIR}"
 ${RUN_AS_LOGIN_USER} "wb resource list --type=GIT_REPO --format json" | \
   jq -c .[] | \
   while read -r ITEM; do
@@ -61,4 +63,5 @@ ${RUN_AS_LOGIN_USER} "wb resource list --type=GIT_REPO --format json" | \
         echo "git clone of ${GIT_REPO_URL} failed."
     fi
   done
-popd || exit
+# shellcheck disable=SC2164
+popd

--- a/startupscript/install-cli.sh
+++ b/startupscript/install-cli.sh
@@ -56,9 +56,17 @@ ${RUN_AS_LOGIN_USER} "wb generate-completion > '${USER_BASH_COMPLETION_DIR}/work
 
 
 if [[ "${LOG_IN}" == "true" ]]; then
+
+  # For GCP use "APP_DEFAULT_CREDENTIALS", for AWS use "AWS_IAM" as --mode arg to "wb auth login".
+  LOG_IN_MODE="APP_DEFAULT_CREDENTIALS"
+  if [[ "${CLOUD}" == "aws" ]]; then
+    LOG_IN_MODE="AWS_IAM"
+  fi
+  readonly LOG_IN_MODE
+
   # Log in with app-default-credentials
-  emit "Logging into workbench CLI with application default credentials"
-  ${RUN_AS_LOGIN_USER} "wb auth login --mode=APP_DEFAULT_CREDENTIALS"
+  emit "Logging into workbench CLI with mode ${LOG_IN_MODE}"
+  ${RUN_AS_LOGIN_USER} "wb auth login --mode=${LOG_IN_MODE}"
 
   # Set the CLI workspace id using the VM metadata, if set.
   TERRA_WORKSPACE="$(get_metadata_value "terra-workspace-id")"

--- a/startupscript/setup-bashrc.sh
+++ b/startupscript/setup-bashrc.sh
@@ -18,6 +18,7 @@
 # - CLOUD: aws/gcp
 # - LOG_IN: whether the user is logged into the wb CLI as part of the script
 # - RUN_AS_LOGIN_USER: run command as non-root Unix user (ex: jupyter, dataproc)
+# - USER_WORKBENCH_CONFIG_DIR: user's WB configuration directory
 # 
 # This script must be run after install-cli.sh
 

--- a/startupscript/setup-bashrc.sh
+++ b/startupscript/setup-bashrc.sh
@@ -72,4 +72,23 @@ EOF
 
 fi
 
+if [[ "${CLOUD}" == "aws" && "${LOG_IN}" == "true" ]]; then
+
+  # Create a symlink to this workspace's AWS config file to use as the target for AWS_CONFIG_FILE.
+  readonly AWS_CONFIG_SYMLINK="${USER_WORKBENCH_CONFIG_DIR}/workspace.conf"
+  ${RUN_AS_LOGIN_USER} "eval \$(wb workspace configure-aws) && \
+    ln -s \${AWS_CONFIG_FILE} ${AWS_CONFIG_SYMLINK}"
+
+  emit "Adding Workbench AWS-sepcific environment variables to ~/.bashrc ..."
+
+  cat << EOF >> "${USER_BASHRC}"
+
+# Set up AWS specific convenience variables
+export AWS_CONFIG_FILE='${AWS_CONFIG_SYMLINK}'
+export AWS_VAULT_BACKEND="file"
+export AWS_VAULT_FILE_PASSPHRASE=""
+EOF
+
+fi
+
 


### PR DESCRIPTION
Enables non-interactive configuration in AWS on par with GCP when no-cred AWS authentication is enabled in the environment.

Key changes:
- Breaks out `aws-vault` config into separate script for reuse.
- Skip all of the extra config steps required when AWS login is enabled (we will be able to remove a bunch of code once AWS no-cred authn has propagated to all envs).
- Use direct call to git instead of `wb git clone --all`.  The CLI "passthrough" commands have a fundamental assumption that Google App Default Creds are configured, which only holds in GCP VM's.  This is pretty baked into the CLI's "external command" design, even though `git` doesn't use ADC, and would require some significant refactoring in CLI to change.  Scripting the same behavior is cloud-agnostic and trivial, so did that here.