### PR TITLE
Skip cloning if repo is already cloned

### DIFF
--- a/startupscript/butane/004-git-clone-devcontainer.sh
+++ b/startupscript/butane/004-git-clone-devcontainer.sh
@@ -24,9 +24,13 @@ git config --system url.https://github.com/.insteadOf git@github.com:
 
 readonly REPO_SRC="$1"
 readonly LOCAL_REPO=/home/core/devcontainer
-if [[ $# -eq 2 ]]; then
-    readonly GIT_BRANCH="$2"
-    git clone "${REPO_SRC}" -b "${GIT_BRANCH}" "${LOCAL_REPO}" 2> /dev/null || git -C "${LOCAL_REPO}" pull
+if [[ -d "${LOCAL_REPO}/.git" ]]; then
+    echo "Git repo already exists, skip cloning..."
 else
-    git clone "${REPO_SRC}" "${LOCAL_REPO}" 2> /dev/null || git -C "${LOCAL_REPO}" pull
+    if [[ $# -eq 2 ]]; then
+        readonly GIT_BRANCH="$2"
+        git clone "${REPO_SRC}" -b "${GIT_BRANCH}" "${LOCAL_REPO}"
+    else
+        git clone "${REPO_SRC}" "${LOCAL_REPO}"
+    fi
 fi

--- a/startupscript/butane/004-git-clone-devcontainer.sh
+++ b/startupscript/butane/004-git-clone-devcontainer.sh
@@ -24,6 +24,8 @@ git config --system url.https://github.com/.insteadOf git@github.com:
 
 readonly REPO_SRC="$1"
 readonly LOCAL_REPO=/home/core/devcontainer
+# Skip on reboot when the devcontainer is already cloned. Because we modify devcontainer template after cloning, pulling
+# will fail.
 if [[ -d "${LOCAL_REPO}/.git" ]]; then
     echo "Git repo already exists, skip cloning..."
 else


### PR DESCRIPTION
Because we modify the template after cloning, devcontainer.service fails on reboot when trying to pull.