### PR TITLE
Fix two bugs in devcontainer parse

### DIFF
--- a/startupscript/butane/005-parse-devcontainer.sh
+++ b/startupscript/butane/005-parse-devcontainer.sh
@@ -34,9 +34,10 @@ sed -i "s/\${templateOption:login}/${LOGIN}/g" "${DEVCONTAINER_CONFIG_PATH}"
 sed -i "s/\${templateOption:cloud}/${CLOUD}/g" "${DEVCONTAINER_CONFIG_PATH}"
 
 echo "publishing devcontainer.json to metadata"
+export PATH="/opt/bin:$PATH"
 # shellcheck source=/dev/null
 source /home/core/metadata-utils.sh
 readonly JSONC_STRIP_COMMENTS=/home/core/jsoncStripComments.mjs
-DEVCONTAINER_CUSTOMIZATIONS=$(${JSONC_STRIP_COMMENTS} < devcontainer/src/rstudio/.devcontainer.json | jq .customizations.workbench)
+DEVCONTAINER_CUSTOMIZATIONS=$(${JSONC_STRIP_COMMENTS} < "${DEVCONTAINER_CONFIG_PATH}" | jq .customizations.workbench)
 readonly DEVCONTAINER_CUSTOMIZATIONS
 set_metadata "devcontainer/customizations" "${DEVCONTAINER_CUSTOMIZATIONS}"


### PR DESCRIPTION
- Script needs to find node in the path.
- Hardcoded config path.