### PR TITLE
Enable CLI installation on libreoffice

### DIFF
--- a/src/libreoffice/.devcontainer.json
+++ b/src/libreoffice/.devcontainer.json
@@ -4,22 +4,21 @@
   "service": "app",
   "shutdownAction": "none",
   "workspaceFolder": "/workspace",
-  // TODO: Enable this once Linux installation is resolved.
-  // "postCreateCommand": [
-  //   "./startupscript/post-startup.sh",
-  //   "abc",
-  //   "/config",
-  //   "${templateOption:cloud}",
-  //   "${templateOption:login}"
-  // ],
-  // // re-mount bucket files on container start up
-  // "postStartCommand": [
-  //   "./startupscript/remount-on-restart.sh",
-  //   "abc",
-  //   "/config",
-  //   "${templateOption:cloud}",
-  //   "${templateOption:login}"
-  // ],
+  "postCreateCommand": [
+    "./startupscript/post-startup.sh",
+    "abc",
+    "/config",
+    "${templateOption:cloud}",
+    "${templateOption:login}"
+  ],
+  // re-mount bucket files on container start up
+  "postStartCommand": [
+    "./startupscript/remount-on-restart.sh",
+    "abc",
+    "/config",
+    "${templateOption:cloud}",
+    "${templateOption:login}"
+  ],
   "remoteUser": "root",
   "features": {
     "./.devcontainer/features/java": {}

--- a/src/libreoffice/docker-compose.yaml
+++ b/src/libreoffice/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "2.4"
 services:
   app:
     container_name: "application-server"

--- a/startupscript/aws/resource-mount.sh
+++ b/startupscript/aws/resource-mount.sh
@@ -15,8 +15,13 @@
 
 if ! which goofys >/dev/null 2>&1; then
   emit "Installing goofys for s3 bucket mounting..."
-  apt-get update
-  apt-get install -y curl
+  if type apk > /dev/null 2>&1; then
+    apk update
+    apk add --no-cache curl
+  elif type apt-get > /dev/null 2>&1; then
+    apt-get update
+    apt-get install -y curl
+  fi
 
   curl -L "https://github.com/kahing/goofys/releases/latest/download/goofys" -o goofys
   chmod +x goofys

--- a/startupscript/gcp/resource-mount.sh
+++ b/startupscript/gcp/resource-mount.sh
@@ -4,6 +4,9 @@
 #
 # Installs gcsfuse if it is not already installed and mount resources.
 #
+# Both apt and install-from-source steps are based on gcloud docs here:
+# https://cloud.google.com/storage/docs/gcsfuse-install
+#
 # Note that this script is intended to be sourced from the "post-startup.sh" script
 # and is dependent on some functions and variables already being set:
 #
@@ -31,7 +34,6 @@ if ! which gcsfuse >/dev/null 2>&1; then
       fuse \
       lsb-release
 
-    # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
     GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
     readonly GCSFUSE_REPO
 

--- a/startupscript/gcp/resource-mount.sh
+++ b/startupscript/gcp/resource-mount.sh
@@ -11,21 +11,35 @@
 # - Workbench CLI is installed
  
 if ! which gcsfuse >/dev/null 2>&1; then
-  emit "Installing gcsfuse..."
+  if type apk > /dev/null 2>&1; then
+    emit "Installing gcsfuse from source..."
 
-  # install packages needed to install gcsfuse
-  apt-get install -y \
-    fuse \
-    lsb-release
+    apk add --no-cache fuse git go
 
-  # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
-  GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
-  readonly GCSFUSE_REPO
+    export GOROOT=/usr/lib/go
+    export GOPATH=/go
+    mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
-  echo "deb https://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" > /etc/apt/sources.list.d/gcsfuse.list
-  curl "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
-  apt-get update \
-    && apt-get install -y gcsfuse
+    go install github.com/googlecloudplatform/gcsfuse/v2@master
+    cp ${GOPATH}/bin/gcsfuse /usr/bin/gcsfuse
+
+  elif type apt-get > /dev/null 2>&1; then
+    emit "Installing gcsfuse from apt package..."
+
+    # install packages needed to install gcsfuse
+    apt-get install -y \
+      fuse \
+      lsb-release
+
+    # Install based on gcloud docs here https://cloud.google.com/storage/docs/gcsfuse-install.
+    GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
+    readonly GCSFUSE_REPO
+
+    echo "deb https://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" > /etc/apt/sources.list.d/gcsfuse.list
+    curl "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
+    apt-get update \
+      && apt-get install -y gcsfuse
+  fi
 else
   emit "gcsfuse already installed. Skipping installation."
 fi

--- a/startupscript/git-setup.sh
+++ b/startupscript/git-setup.sh
@@ -35,8 +35,13 @@ fi
 rm -f "${USER_SSH_DIR}/id_rsa.tmp"
 
 # Set the github known_hosts
-apt-get update
-apt-get install -y openssh-client
+if type apk > /dev/null 2>&1; then
+  apk update
+  apk add --no-cache openssh-client
+elif type apt-get > /dev/null 2>&1; then
+  apt-get update
+  apt-get install -y openssh-client
+fi
 ${RUN_AS_LOGIN_USER} "ssh-keyscan -H github.com >> '${USER_SSH_DIR}/known_hosts'"
 
 # Create git repos directory

--- a/startupscript/post-startup.sh
+++ b/startupscript/post-startup.sh
@@ -61,7 +61,7 @@ if type apk > /dev/null 2>&1; then
   apk add --no-cache jq curl fuse tar wget
 elif type apt-get > /dev/null 2>&1; then
   apt-get update
-  apt install -y jq curl fuse tar wgetelif
+  apt install -y jq curl fuse tar wget
 else
   >&2 echo "ERROR: Unable to find a supported package manager"
   exit 1

--- a/startupscript/post-startup.sh
+++ b/startupscript/post-startup.sh
@@ -56,8 +56,17 @@ exec >> "${POST_STARTUP_OUTPUT_FILE}"
 exec 2>&1
 
 # The apt package index may not be clean when we run; resynchronize
-apt-get update
-apt install -y jq curl fuse tar wget
+if type apk > /dev/null 2>&1; then
+  apk update
+  apk add --no-cache jq curl fuse tar wget
+elif type apt-get > /dev/null 2>&1; then
+  apt-get update
+  apt install -y jq curl fuse tar wgetelif
+else
+  >&2 echo "ERROR: Unable to find a supported package manager"
+  exit 1
+fi
+
 
 # Create the target directories for installing into the HOME directory
 ${RUN_AS_LOGIN_USER} "mkdir -p '${USER_BASH_COMPLETION_DIR}'"


### PR DESCRIPTION
Changes include (mainly for alpine Linux):
- Using APK package manager instead of APT.
- Installing gcsfuse from source as it is not available for APK.