### PR TITLE
Fix setting metadata on aws that contains special cars

### DIFF
--- a/startupscript/butane/005-parse-devcontainer.sh
+++ b/startupscript/butane/005-parse-devcontainer.sh
@@ -38,6 +38,6 @@ export PATH="/opt/bin:$PATH"
 # shellcheck source=/dev/null
 source /home/core/metadata-utils.sh
 readonly JSONC_STRIP_COMMENTS=/home/core/jsoncStripComments.mjs
-DEVCONTAINER_CUSTOMIZATIONS=$(${JSONC_STRIP_COMMENTS} < "${DEVCONTAINER_CONFIG_PATH}" | jq -c .customizations.workbench)
+DEVCONTAINER_CUSTOMIZATIONS="$("${JSONC_STRIP_COMMENTS}" < "${DEVCONTAINER_CONFIG_PATH}" | jq -c .customizations.workbench)"
 readonly DEVCONTAINER_CUSTOMIZATIONS
 set_metadata "devcontainer/customizations" "${DEVCONTAINER_CUSTOMIZATIONS}"

--- a/startupscript/butane/005-parse-devcontainer.sh
+++ b/startupscript/butane/005-parse-devcontainer.sh
@@ -38,6 +38,6 @@ export PATH="/opt/bin:$PATH"
 # shellcheck source=/dev/null
 source /home/core/metadata-utils.sh
 readonly JSONC_STRIP_COMMENTS=/home/core/jsoncStripComments.mjs
-DEVCONTAINER_CUSTOMIZATIONS=$(${JSONC_STRIP_COMMENTS} < "${DEVCONTAINER_CONFIG_PATH}" | jq .customizations.workbench)
+DEVCONTAINER_CUSTOMIZATIONS=$(${JSONC_STRIP_COMMENTS} < "${DEVCONTAINER_CONFIG_PATH}" | jq -c .customizations.workbench)
 readonly DEVCONTAINER_CUSTOMIZATIONS
 set_metadata "devcontainer/customizations" "${DEVCONTAINER_CUSTOMIZATIONS}"

--- a/startupscript/butane/aws/metadata-utils.sh
+++ b/startupscript/butane/aws/metadata-utils.sh
@@ -49,6 +49,9 @@ readonly -f get_guest_attribute
 function set_metadata() {
   local key="${1}"
   local value="${2}"
+  # Per the AWS CLI documentation, value is provided within quotes,
+  # with " and \ escaped with a \ prefix.
+  # https://docs.aws.amazon.com/cli/latest/reference/ec2/create-tags.html
   local escaped="${value//[\"\\]/\\&}"
 
   echo "Creating tag vwbapp:${key} to ${value}"

--- a/startupscript/butane/aws/metadata-utils.sh
+++ b/startupscript/butane/aws/metadata-utils.sh
@@ -28,7 +28,7 @@ function get_tag() {
     echo "${tag_value}"
   fi
 }
-readonly -f get_tag 
+readonly -f get_tag
 
 # EC2 instance uses tags instead of metadata. But to keep the iterface consistent with GCP, this method retrieves tags set by the user.
 # They are prefixed with vwbusr.
@@ -49,17 +49,18 @@ readonly -f get_guest_attribute
 function set_metadata() {
   local key="${1}"
   local value="${2}"
-  
+  local escaped="${value//[\"\\]/\\&}"
+
   echo "Creating tag vwbapp:${key} to ${value}"
   local token
   token=$(wget --method=PUT --header "X-aws-ec2-metadata-token-ttl-seconds:600" -q -O - http://169.254.169.254/latest/api/token)
   local id
   id=$(wget --header "X-aws-ec2-metadata-token: ${token}" -q -O - http://169.254.169.254/latest/meta-data/instance-id)
 
-  docker run --rm --detach --network host \
+  docker run --rm --network host \
     public.ecr.aws/aws-cli/aws-cli \
     ec2 create-tags \
       --resources "${id}" \
-      --tags Key=vwbapp:"${key}",Value="${value}"
+      --tags Key="\"vwbapp:${key}\",Value=\"${escaped}\""
 }
 readonly -f set_metadata


### PR DESCRIPTION
- Quotes and backslashes need to be escaped
- Also make the json we write more compact as there is a size limit