### PR TITLE
update rstudio image to bump version to 4.4

### DIFF
--- a/src/rstudio/docker-compose.yaml
+++ b/src/rstudio/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
-    image: "ghcr.io/rocker-org/devcontainer/tidyverse:4.2"
+    image: "ghcr.io/rocker-org/devcontainer/tidyverse:4.4"
     restart: always
     volumes:
       - .:/workspace:cached


### PR DESCRIPTION
I tested this via a fork and it (superficially) seemed to be fine.
I tested in devel.