### PR TITLE
Safely mount resources on custom apps

### DIFF
--- a/src/cirrocumulus/scripts/cirro_scanner.sh
+++ b/src/cirrocumulus/scripts/cirro_scanner.sh
@@ -39,7 +39,7 @@ function scan_folders_and_create_datasets() {
 }
 readonly -f scan_folders_and_create_datasets
 
-wb resource mount || true
+wb resource mount || echo 'Resource mounting failed.'
 
 # Infinite loop to continuously scan every 5 seconds
 while true; do

--- a/startupscript/aws/resource-mount.sh
+++ b/startupscript/aws/resource-mount.sh
@@ -35,5 +35,5 @@ if [[ "${LOG_IN}" == "true" ]]; then
   ${RUN_AS_LOGIN_USER} "export AWS_VAULT_BACKEND='file' && \
     export AWS_VAULT_FILE_PASSPHRASE='' && \
     eval  \$(wb workspace configure-aws) && \
-    wb resource mount || true"
+    wb resource mount || echo 'Resource mounting failed.'"
 fi

--- a/startupscript/gcp/resource-mount.sh
+++ b/startupscript/gcp/resource-mount.sh
@@ -50,5 +50,5 @@ fi
 sed -i '/user_allow_other/s/^#//g' /etc/fuse.conf
 
 if [[ "${LOG_IN}" == "true" ]]; then
-  ${RUN_AS_LOGIN_USER} "wb resource mount --allow-other || true"
+  ${RUN_AS_LOGIN_USER} "wb resource mount --allow-other || echo 'Resource mounting failed.'"
 fi


### PR DESCRIPTION
Currently during new custom app creation, the resource mount script non zero exit codes are treated as failures and is surfaced as a post startup script failure.

This PR relies on the existing `remount-on-restart.sh` script to mount resources on creation too. It properly supresses non-zero exist codes from resource mounting.

https://verily.atlassian.net/browse/BENCH-5367