### PR TITLE
Prevent unintended variable expansion in modifying the path var in the bashrc code snippet

### DIFF
--- a/startupscript/post-startup.sh
+++ b/startupscript/post-startup.sh
@@ -170,8 +170,8 @@ cat << EOF >> "${USER_BASHRC}"
 ### BEGIN: Workbench-specific customizations ###
 
 # Prepend "/usr/bin" (if not already in the path)
-if [[ "${PATH}:" != "/usr/bin:"* ]]; then
-  export PATH=/usr/bin:${PATH}
+if [[ "\${PATH}:" != "/usr/bin:"* ]]; then
+  export PATH=/usr/bin:\${PATH}
 fi
 EOF
 


### PR DESCRIPTION
The startupscript adds a code snippet to bashrc that modifies the path variable. However the startup script does not escape $, resulting in the PATH var expanding into the value of the PATH var at the execution time of the startup script. This is breaking anyone from adding paths to PATH.