### PR TITLE
Add docker cache scripts

### DIFF
--- a/startupscript/butane/attach-docker-cache.sh
+++ b/startupscript/butane/attach-docker-cache.sh
@@ -10,6 +10,7 @@ set -o pipefail
 set -o xtrace
 
 function attach {
+  # Increase the levels of indirection for xtrace
   PS4="++ "
   set -o errexit
   set -o nounset
@@ -17,7 +18,8 @@ function attach {
   set -o xtrace
 
   local DISK_NAME="${1}"
-  local DISK_UUID="$(blkid -o value -s UUID "${DISK_NAME}")"
+  local DISK_UUID
+  DISK_UUID="$(blkid -o value -s UUID "${DISK_NAME}")"
   local MOUNTPOINT="/dc/${DISK_UUID}"
   local DOCKER_ROOT="/var/lib/docker"
 

--- a/startupscript/butane/attach-docker-cache.sh
+++ b/startupscript/butane/attach-docker-cache.sh
@@ -10,50 +10,60 @@ set -o pipefail
 set -o xtrace
 
 function attach {
-  if findmnt "${1}" > /dev/null; then
-    echo "${1} is already mounted"
+  PS4="++ "
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+  set -o xtrace
+
+  local DISK_NAME="${1}"
+  local DISK_UUID="$(blkid -o value -s UUID "${DISK_NAME}")"
+  local MOUNTPOINT="/dc/${DISK_UUID}"
+  local DOCKER_ROOT="/var/lib/docker"
+
+  if findmnt "${DISK_NAME}" > /dev/null; then
+    echo "${DISK_NAME} is already mounted"
     return
   fi
 
   # Mount the read-only cache to a directory by its UUID, so that it will be
   # mounted at the same point across reboots
-  id="$(blkid -o value -s UUID "${1}")"
-  mkdir -p "/dc/${id}"
-  mount -o ro "${1}" "/dc/${id}"
+  mkdir -p "${MOUNTPOINT}"
+  mount -o ro "${DISK_NAME}" "${MOUNTPOINT}"
 
   # Copy the overlay2 directories to the docker cache
   # shellcheck disable=SC2016
   find_args=(
-      "/dc/${id}/overlay2" -maxdepth 1 -mindepth 1 -type d
+    "${MOUNTPOINT}/overlay2" -maxdepth 1 -mindepth 1 -type d
 
-      # Skip the "l" directory for now, since it contains relative symlinks that
-      # we will copy directly in the next step
-      ! -name "l"
+    # Skip the "l" directory for now, since it contains relative symlinks that
+    # we will copy directly in the next step
+    ! -name "l"
 
-      # If the directory already exists, skip the remaining steps. Pass the file
-      # name as a shell parameter to avoid malicious injection.
-      -execdir bash -c '[ ! -d "/var/lib/docker/overlay2/${1}" ] || (echo "Skipping existing directory ${1}"; exit 1)' shell "{}" \;
+    # If the directory already exists, skip the remaining steps. Pass the file
+    # name as a shell parameter to avoid malicious injection.
+    -execdir bash -c '[ ! -d "${1}" ] || (echo "Skipping existing directory ${1}"; exit 1)' shell "${DOCKER_ROOT}/overlay2/{}" \;
 
-      # Copy the layer's metadata, preserving all file permissions. diff will be
-      # handled in the next step, while work and merged are temporary
-      # directories that we do not want to include
-      -execdir rsync -a --exclude="diff" --exclude "work" --exclude "merged" "{}" /var/lib/docker/overlay2/ \;
+    # Copy the layer's metadata, preserving all file permissions. diff will be
+    # handled in the next step, while work and merged are temporary
+    # directories that we do not want to include
+    -execdir rsync -a --exclude="diff" --exclude "work" --exclude "merged" "{}" /var/lib/docker/overlay2/ \;
 
-      # The diff directory contains the actual data. Since overlayfs is able to
-      # understand symlinks, we can just symlink the diff directory to the read-only
-      # cache. We cannot simply symlink the entire directory, since docker needs
-      # to create read-write work and merged directories to merge the layers
-      -execdir ln -s "/dc/${id}/overlay2/{}/diff" "/var/lib/docker/overlay2/{}/diff" \;
+    # The diff directory contains the actual data. Since overlayfs is able to
+    # understand symlinks, we can just symlink the diff directory to the read-only
+    # cache. We cannot simply symlink the entire directory, since docker needs
+    # to create read-write work and merged directories to merge the layers
+    -execdir ln -s "${MOUNTPOINT}/overlay2/{}/diff" "${DOCKER_ROOT}/overlay2/{}/diff" \;
   )
   find "${find_args[@]}"
 
   # Copy the links, ignoring existing files. These are relative symlinks, of the
   # format <short_id> -> ../<long_layer_id>
-  rsync --ignore-existing -a "/dc/${id}/overlay2/l/" "/var/lib/docker/overlay2/l"
+  rsync --ignore-existing -a "${MOUNTPOINT}/overlay2/l/" "${DOCKER_ROOT}/overlay2/l"
 
   # Copy the required image directories, ignoring existing files
-  rsync --ignore-existing -a "/dc/${id}/image/overlay2/distribution/diffid-by-digest/sha256/" "/var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256"
-  rsync --ignore-existing -a "/dc/${id}/image/overlay2/layerdb/sha256/" "/var/lib/docker/image/overlay2/layerdb/sha256"
+  rsync --ignore-existing -a "${MOUNTPOINT}/image/overlay2/distribution/diffid-by-digest/sha256/" "${DOCKER_ROOT}/image/overlay2/distribution/diffid-by-digest/sha256"
+  rsync --ignore-existing -a "${MOUNTPOINT}/image/overlay2/layerdb/sha256/" "${DOCKER_ROOT}/image/overlay2/layerdb/sha256"
 }
 readonly -f attach
 export -f attach
@@ -71,7 +81,12 @@ mkdir -p /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
 mkdir -p /var/lib/docker/image/overlay2/layerdb/sha256
 chmod 700 -R /var/lib/docker/image
 
-# Look for disk cache partitions, with priority to vwb caches
+# Look for disk cache partitions, with priority to vwb caches. The attach
+# function ignores anything that already exists, so by attaching the first-party
+# VWB caches first, we can establish the priority:
+#   1. local files
+#   2. VWB caches
+#   3. user-supplied caches
 # shellcheck disable=SC2016
 find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_vwb-docker-cache-*-part*" -exec bash -c 'attach "${1}"' shell "{}" \;
 # shellcheck disable=SC2016

--- a/startupscript/butane/attach-docker-cache.sh
+++ b/startupscript/butane/attach-docker-cache.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# attach-docker-cache.sh scans for any newly attached docker cache disks and
+# mounts them and integrates them with the docker root directory.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+function attach {
+  if findmnt "${1}" > /dev/null; then
+    echo "${1} is already mounted"
+    return
+  fi
+
+  id="$(uuidgen)"
+  mkdir -p "/dc/${id}"
+
+  mount "${1}" "/dc/${id}"
+
+
+  cd "/dc/${id}/overlay2"
+
+  # Copy the overlay2 directories to the docker cache, symlinking the diff
+  # directories and excluding the work and merged directories. Skip directories
+  # that already exist
+  find . -maxdepth 1 -mindepth 1 -type d ! -name "l" \
+      -exec bash -c '[ ! -d "/var/lib/docker/overlay2/{}" ] || (echo "Skipping existing directory {}"; exit 1)' \
+      -exec rsync -a --exclude="diff" --exclude "work" --exclude "merged" "{}" /var/lib/docker/overlay2/ \; \
+      -exec ln -s "/dc/${id}/overlay2/{}/diff" "/var/lib/docker/overlay2/{}/diff" \;
+
+  # Copy the links, ignoring existing files
+  rsync --ignore-existing -a ./l/ /var/lib/docker/overlay2/l
+
+  cd "/dc/${id}/image/overlay2"
+
+  # Copy the required image directories, ignoring existing files
+  rsync --ignore-existing -a ./distribution/diffid-by-digest/sha256/ /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
+  rsync --ignore-existing -a ./layerdb/sha256/ /var/lib/docker/image/overlay2/layerdb/sha256
+}
+readonly -f attach
+export -f attach
+
+# Set up the required docker directories if they don't exist
+chmod 710 /var/lib/docker
+mkdir -p /var/lib/docker/overlay2
+chmod 710 /var/lib/docker/overlay2
+mkdir -p /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
+mkdir -p /var/lib/docker/image/overlay2/layerdb/sha256
+chmod 700 -R /var/lib/docker/image
+
+# Look for disk cache partitions, with priority to vwb caches
+find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_vwb-docker-cache-*-part*" -exec bash -c 'attach "{}"' \;
+find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_docker-cache-*-part*" -exec bash -c 'attach "{}"' \;

--- a/startupscript/butane/attach-docker-cache.sh
+++ b/startupscript/butane/attach-docker-cache.sh
@@ -21,30 +21,40 @@ function attach {
   mkdir -p "/dc/${id}"
   mount -o ro "${1}" "/dc/${id}"
 
-  # Copy the overlay2 directories to the docker cache, symlinking the diff
-  # directories and excluding the work and merged directories. Skip directories
-  # that already exist. We are skipping the "l" directory for now, since it
-  # contains relative symlinks that we will copy directly in the next step
-  find /dc/${id}/overlay2 -maxdepth 1 -mindepth 1 -type d ! -name "l" \
+  # Copy the overlay2 directories to the docker cache
+  find_args=(
+      "/dc/${id}/overlay2" -maxdepth 1 -mindepth 1 -type d
+
+      # Skip the "l" directory for now, since it contains relative symlinks that
+      # we will copy directly in the next step
+      ! -name "l"
+
       # If the directory already exists, skip the remaining steps
-      -execdir bash -c '[ ! -d "/var/lib/docker/overlay2/${1}" ] || (echo "Skipping existing directory ${1}"; exit 1)' shell "{}" \; \
+      # shellcheck disable=SC2016
+      -execdir bash -c '[ ! -d "/var/lib/docker/overlay2/${1}" ] || (echo "Skipping existing directory ${1}"; exit 1)' shell "{}" \;
+
       # Copy the layer's metadata, preserving all file permissions. diff will be
       # handled in the next step, while work and merged are temporary
       # directories that we do not want to include
-      -execdir bash -c 'rsync -a --exclude="diff" --exclude "work" --exclude "merged" "${1}" /var/lib/docker/overlay2/' shell "{}" \; \
+      # shellcheck disable=SC2016
+      -execdir bash -c 'rsync -a --exclude="diff" --exclude "work" --exclude "merged" "${1}" /var/lib/docker/overlay2/' shell "{}" \;
+
       # The diff directory contains the actual data. Since overlayfs is able to
       # understand symlinks, we can just symlink the diff directory to the read-only
       # cache. We cannot simply symlink the entire directory, since docker needs
       # to create read-write work and merged directories to merge the layers
+      # shellcheck disable=SC2016
       -execdir bash -c 'ln -s "/dc/${2}/overlay2/${1}/diff" "/var/lib/docker/overlay2/${1}/diff"' shell "{}" "${id}" \;
+  )
+  find "${find_args[@]}"
 
   # Copy the links, ignoring existing files. These are relative symlinks, of the
   # format <short_id> -> ../<long_layer_id>
-  rsync --ignore-existing -a /dc/${id}/overlay2/l/ /var/lib/docker/overlay2/l
+  rsync --ignore-existing -a "/dc/${id}/overlay2/l/" "/var/lib/docker/overlay2/l"
 
   # Copy the required image directories, ignoring existing files
-  rsync --ignore-existing -a /dc/${id}/image/overlay2/distribution/diffid-by-digest/sha256/ /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
-  rsync --ignore-existing -a /dc/${id}/image/overlay2/layerdb/sha256/ /var/lib/docker/image/overlay2/layerdb/sha256
+  rsync --ignore-existing -a "/dc/${id}/image/overlay2/distribution/diffid-by-digest/sha256/" "/var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256"
+  rsync --ignore-existing -a "/dc/${id}/image/overlay2/layerdb/sha256/" "/var/lib/docker/image/overlay2/layerdb/sha256"
 }
 readonly -f attach
 export -f attach
@@ -63,5 +73,7 @@ mkdir -p /var/lib/docker/image/overlay2/layerdb/sha256
 chmod 700 -R /var/lib/docker/image
 
 # Look for disk cache partitions, with priority to vwb caches
+# shellcheck disable=SC2016
 find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_vwb-docker-cache-*-part*" -exec bash -c 'attach "${1}"' shell "{}" \;
+# shellcheck disable=SC2016
 find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_docker-cache-*-part*" -exec bash -c 'attach "${1}"' shell "{}" \;

--- a/startupscript/butane/attach-docker-cache.sh
+++ b/startupscript/butane/attach-docker-cache.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # attach-docker-cache.sh scans for any newly attached docker cache disks and
-# mounts them and integrates them with the docker root directory.
+# mounts them and integrates them with the docker root directory. This should
+# run on system boot, before docker is started.
 
 set -o errexit
 set -o nounset
@@ -14,42 +15,53 @@ function attach {
     return
   fi
 
-  id="$(uuidgen)"
+  # Mount the read-only cache to a directory by its UUID, so that it will be
+  # mounted at the same point across reboots
+  id="$(blkid -o value -s UUID "${1}")"
   mkdir -p "/dc/${id}"
-
-  mount "${1}" "/dc/${id}"
-
-
-  cd "/dc/${id}/overlay2"
+  mount -o ro "${1}" "/dc/${id}"
 
   # Copy the overlay2 directories to the docker cache, symlinking the diff
   # directories and excluding the work and merged directories. Skip directories
-  # that already exist
-  find . -maxdepth 1 -mindepth 1 -type d ! -name "l" \
-      -exec bash -c '[ ! -d "/var/lib/docker/overlay2/{}" ] || (echo "Skipping existing directory {}"; exit 1)' \
-      -exec rsync -a --exclude="diff" --exclude "work" --exclude "merged" "{}" /var/lib/docker/overlay2/ \; \
-      -exec ln -s "/dc/${id}/overlay2/{}/diff" "/var/lib/docker/overlay2/{}/diff" \;
+  # that already exist. We are skipping the "l" directory for now, since it
+  # contains relative symlinks that we will copy directly in the next step
+  find /dc/${id}/overlay2 -maxdepth 1 -mindepth 1 -type d ! -name "l" \
+      # If the directory already exists, skip the remaining steps
+      -execdir bash -c '[ ! -d "/var/lib/docker/overlay2/${1}" ] || (echo "Skipping existing directory ${1}"; exit 1)' shell "{}" \; \
+      # Copy the layer's metadata, preserving all file permissions. diff will be
+      # handled in the next step, while work and merged are temporary
+      # directories that we do not want to include
+      -execdir bash -c 'rsync -a --exclude="diff" --exclude "work" --exclude "merged" "${1}" /var/lib/docker/overlay2/' shell "{}" \; \
+      # The diff directory contains the actual data. Since overlayfs is able to
+      # understand symlinks, we can just symlink the diff directory to the read-only
+      # cache. We cannot simply symlink the entire directory, since docker needs
+      # to create read-write work and merged directories to merge the layers
+      -execdir bash -c 'ln -s "/dc/${2}/overlay2/${1}/diff" "/var/lib/docker/overlay2/${1}/diff"' shell "{}" "${id}" \;
 
-  # Copy the links, ignoring existing files
-  rsync --ignore-existing -a ./l/ /var/lib/docker/overlay2/l
-
-  cd "/dc/${id}/image/overlay2"
+  # Copy the links, ignoring existing files. These are relative symlinks, of the
+  # format <short_id> -> ../<long_layer_id>
+  rsync --ignore-existing -a /dc/${id}/overlay2/l/ /var/lib/docker/overlay2/l
 
   # Copy the required image directories, ignoring existing files
-  rsync --ignore-existing -a ./distribution/diffid-by-digest/sha256/ /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
-  rsync --ignore-existing -a ./layerdb/sha256/ /var/lib/docker/image/overlay2/layerdb/sha256
+  rsync --ignore-existing -a /dc/${id}/image/overlay2/distribution/diffid-by-digest/sha256/ /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
+  rsync --ignore-existing -a /dc/${id}/image/overlay2/layerdb/sha256/ /var/lib/docker/image/overlay2/layerdb/sha256
 }
 readonly -f attach
 export -f attach
 
 # Set up the required docker directories if they don't exist
 chmod 710 /var/lib/docker
+# overlay2 contains the layer data
 mkdir -p /var/lib/docker/overlay2
 chmod 710 /var/lib/docker/overlay2
+# image/overlay2/distribution/diffid-by-digest/sha256 maps the image digest to
+# the diff hash
 mkdir -p /var/lib/docker/image/overlay2/distribution/diffid-by-digest/sha256
+# image/overlay2/layerdb/sha256 contains the image metadata, including the layer
+# ID, parent image, and size of the layer
 mkdir -p /var/lib/docker/image/overlay2/layerdb/sha256
 chmod 700 -R /var/lib/docker/image
 
 # Look for disk cache partitions, with priority to vwb caches
-find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_vwb-docker-cache-*-part*" -exec bash -c 'attach "{}"' \;
-find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_docker-cache-*-part*" -exec bash -c 'attach "{}"' \;
+find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_vwb-docker-cache-*-part*" -exec bash -c 'attach "${1}"' shell "{}" \;
+find /dev/disk/by-id/ -maxdepth 1 -name "scsi-0Google_PersistentDisk_docker-cache-*-part*" -exec bash -c 'attach "${1}"' shell "{}" \;

--- a/startupscript/butane/prepare-devcontainer-cache.sh
+++ b/startupscript/butane/prepare-devcontainer-cache.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# prepare-devcontainer-cache.sh prepares the devcontainer to be saved as a disk
+# image.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+function usage {
+  echo "Usage: $0 <additonal_images>"
+  echo "  additional_images: additional docker images to cache."
+  exit 1
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" ]]; then
+  usage
+fi
+
+# Pull any requested images
+for image in "$@"; do
+  docker image pull "${image}"
+done
+
+# Stop docker and prevent it from starting again
+systemctl mask docker
+systemctl stop docker
+
+# Remove any extraneous files. We only need to keep the images and the overlay2
+# directories.
+find /var/lib/docker \
+    ! -name image \
+    ! -name overlay2 \
+    -mindepth 1 -maxdepth 1 \
+    -exec rm -rf {} +
+
+# shellcheck source=/dev/null
+source '/home/core/metadata-utils.sh'
+set_metadata 'startup_script/status' "COMPLETED"
+
+# Shut down the instance to signal that the image is ready to be saved.
+systemctl poweroff


### PR DESCRIPTION
`prepare-devcontainer-cache.sh` prepares the devcontainer to be saved as a disk image

`attach-docker-cache.sh` scans for any newly attached docker cache disks and mounts them and integrates them with the docker root directory.

BENCH-5651