### PR TITLE
[BENCH-5473] Switching Dataproc to Use Workbench Proxy

### DIFF
--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -173,7 +173,7 @@ readonly -f emit
 function get_metadata_value() {
   local metadata_path="${1}"
   curl --retry 5 -s -f \
-      -H "Metadata-Flavor: Google" \
+    -H "Metadata-Flavor: Google" \
       "http://metadata/computeMetadata/v1/${metadata_path}" \
     || echo -n
 }
@@ -197,20 +197,46 @@ function set_guest_attributes() {
 # Map the CLI server to appropriate service path
 function get_service_url() {
   case "$1" in
-    "verily") echo "https://terra-$2.api.verily.com" ;;
-    "verily-devel") echo "https://terra-devel-$2.api.verily.com" ;;
-    "verily-autopush") echo "https://terra-autopush-$2.api.verily.com" ;;
-    "verily-staging") echo "https://terra-staging-$2.api.verily.com" ;;
-    "verily-preprod") echo "https://terra-preprod-$2.api.verily.com" ;;
-    "dev-stable") echo "https://workbench-dev.verily.com/api/$2" ;;
-    "dev-unstable") echo "https://workbench-dev-unstable.verily.com/api/$2" ;;
-    "test") echo "https://workbench-test.verily.com/api/$2" ;;
-    "staging") echo "https://workbench-staging.verily.com/api/$2" ;;
-    "prod") echo "https://workbench-prod.verily.com/api/$2" ;;
-    *) return 1 ;;
+  "verily") echo "https://workbench.verily.com/api/$2" ;;
+  "dev-stable") echo "https://workbench-dev.verily.com/api/$2" ;;
+  "dev-unstable") echo "https://workbench-dev-unstable.verily.com/api/$2" ;;
+  "test") echo "https://workbench-test.verily.com/api/$2" ;;
+  "staging") echo "https://workbench-staging.verily.com/api/$2" ;;
+  "prod") echo "https://workbench.verily.com/api/$2" ;;
+  *) return 1 ;;
   esac
 }
 readonly -f get_service_url
+
+# Get the app proxy url for the env.
+function get_app_proxy_uri() {
+  local env="${1}"
+  case "${env}" in
+  "verily")
+    env="prod"
+    ;;
+  "dev-stable")
+    env="dev"
+    ;;
+  esac
+  echo "workbench-app-${env}.verily.com"
+}
+readonly -f get_app_proxy_uri
+
+# Get workbench frontend url
+function get_ui_uri() {
+  local env="${1}"
+  if [[ "${env}" == "verily" || "${env}" == "prod" ]]; then
+    echo "https://workbench.verily.com"
+  elif [[ "${env}" == "dev-stable" ]]; then
+    echo "https://workbench-dev.verily.com"
+  elif [[ "${env}" == "dev-unstable" || "${env}" == "test" || "${env}" == "staging" ]]; then
+    echo "https://workbench-${env}.verily.com"
+  else
+    echo "https://workbench.verily.com"
+  fi
+}
+readonly -f get_ui_uri
 
 # If the script exits without error let the UI know it completed successfully
 # Otherwise if an error occurred write the line and command that failed to guest attributes.
@@ -267,7 +293,7 @@ function install_nextflow() {
 readonly -f install_nextflow
 
 #######################################
-### Begin environment setup 
+### Begin environment setup
 #######################################
 
 # Let the UI know the script has started
@@ -601,7 +627,7 @@ EOF
 
 emit "Setting up git integration..."
 
-# Create the user SSH directory 
+# Create the user SSH directory
 ${RUN_AS_LOGIN_USER} "mkdir -p ${USER_SSH_DIR} --mode 0700"
 
 # Get the user's SSH key from Workbench, and if set, write it to the user's .ssh directory
@@ -804,32 +830,73 @@ readonly IS_NON_GOOGLE_ACCOUNT
 
 ENABLE_VWB_PROXY="$(get_metadata_value "instance/attributes/enable-dataproc-vwb-proxy")"
 readonly ENABLE_VWB_PROXY
-if [[ "${IS_NON_GOOGLE_ACCOUNT}" == "true" ]] || [[ "${ENABLE_VWB_PROXY}" == "true" ]]; then
-  USE_VWB_PROXY="true"
-else
-  USE_VWB_PROXY="false"
-fi
-readonly USE_VWB_PROXY
+# Retrieve Workbench proxy agent image
+PROXY_IMAGE="$(get_metadata_value "instance/attributes/proxy-image")"
+readonly PROXY_IMAGE
+APP_PROXY="$(get_app_proxy_uri "${TERRA_SERVER}")"
+readonly APP_PROXY
+RESOURCE_ID="$(get_metadata_value "instance/attributes/terra-resource-id")"
+readonly RESOURCE_ID
+# Retrieve app proxy user facing URL
+APP_PROXY_URL="https://${RESOURCE_ID}.${APP_PROXY}"
+readonly APP_PROXY_URL
+# Retrieve app proxy service facing URL
+PROXY_SERVICE_URL="$(get_service_url "${TERRA_SERVER}" "proxy")/"
+readonly PROXY_SERVICE_URL
 
-APP_PROXY=""
-if [[ "${USE_VWB_PROXY}" == "true" ]]; then
+# Define constants for proxy types
+PROXY_TYPE_VWB="VWB_PROXY"
+PROXY_TYPE_GOOGLE="GOOGLE_PROXY"
+PROXY_TYPE_GOOGLE_AGENT_WITH_VWB_PROXY="GOOGLE_AGENT_WITH_VWB_PROXY"
+
+# Decide proxy type
+PROXY_TYPE=""
+if [[ ${ENABLE_VWB_PROXY} == "true" && -n "${PROXY_IMAGE}" ]]; then
+  PROXY_TYPE="${PROXY_TYPE_VWB}"
+elif [[ ${IS_NON_GOOGLE_ACCOUNT} == "true" ]]; then
+  PROXY_TYPE="${PROXY_TYPE_GOOGLE_AGENT_WITH_VWB_PROXY}"
+else
+  PROXY_TYPE="${PROXY_TYPE_GOOGLE}"
+fi
+
+if [[ "${PROXY_TYPE}" != "${PROXY_TYPE_GOOGLE}" ]]; then
 ###################################
 # Start workbench app proxy agent 
 ###################################
+    if [[ "${PROXY_TYPE}" == "${PROXY_TYPE_VWB}" ]]; then
+      emit "Using Workbench Proxy"
+      ENABLE_MONITORING_SCRIPT="$(get_metadata_value "instance/attributes/enable-dataproc-monitoring-script")"
+      readonly ENABLE_MONITORING_SCRIPT
 
-  APP_PROXY="$(get_metadata_value "instance/attributes/terra-app-proxy")"
-  readonly APP_PROXY
-  if [[ -n "${APP_PROXY}" ]]; then
-    emit "Using custom Proxy Agent"
-    RESOURCE_ID="$(get_metadata_value "instance/attributes/terra-resource-id")"
-    NEW_PROXY="https://${APP_PROXY}"
-    NEW_PROXY_URL="${RESOURCE_ID}.${APP_PROXY}"
-    readonly RESOURCE_ID
-    readonly NEW_PROXY
-    readonly NEW_PROXY_URL
+      cat <<EOF >"${WORKBENCH_PROXY_AGENT_SERVICE}"
+[Unit]
+Description=Workbench Docker Proxy Agent
+After=docker.service
+Requires=docker.service
 
-    # Create a systemd service to start the workbench app proxy.
-    cat << EOF > "${WORKBENCH_PROXY_AGENT_SERVICE}"
+[Service]
+ExecStartPre=/bin/bash -c 'while [ ! -f ${PROXY_AGENT_BANNER} ]; do sleep 5; done'
+ExecStart=/bin/bash -c '/usr/bin/docker run \\
+      --detach \\
+      --name "proxy-agent" \\
+      --restart=unless-stopped \\
+      --net=host "${PROXY_IMAGE}" \\
+      --proxy="${PROXY_SERVICE_URL}" \\
+      --host="localhost:8123" \\
+      --compute-platform="GCP" \\
+      --shim-path="websocket-shim" \\
+      --rewrite-websocket-host="true" \\
+      --backend="${RESOURCE_ID}" \\
+      --session-cookie-name="_xsrf" \\
+      --inject-banner="\$(cat /opt/dataproc/proxy-agent/banner.html)" \\
+      --enable-monitoring-script="${ENABLE_MONITORING_SCRIPT:-false}"'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    else
+      emit "Using Google Proxy Agent with Workbench Proxy"
+      cat <<EOF >"${WORKBENCH_PROXY_AGENT_SERVICE}"
 [Unit]
 Description=Workbench App Proxy Agent Service
 
@@ -840,13 +907,16 @@ Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 EOF
+    fi
 
     # Enable and start the workbench app proxy agent service
     systemctl daemon-reload
     systemctl enable "${WORKBENCH_PROXY_AGENT_SERVICE_NAME}"
-    systemctl start "${WORKBENCH_PROXY_AGENT_SERVICE_NAME}"
-    emit "Workbench Proxy Agent service started"
-  fi
+    # Start the service in non-blocking mode to allow startup script to continue without waiting
+    systemctl --no-block start "${WORKBENCH_PROXY_AGENT_SERVICE_NAME}"
+    emit "Workbench Proxy Agent started"
+else
+  emit "Using Google Proxy"
 fi
 
 ###################################
@@ -1057,24 +1127,13 @@ fi
     emit "Starting Hail install script..."
     ${RUN_PYTHON} ${HAIL_SCRIPT_PATH}
   fi
-  
-  if [[ "${USE_VWB_PROXY}" == "false" ]]; then
-  ######################################################
-  # Configure the original (non-workbench) proxy agent
-  ######################################################
+
+  if [[ "${IS_NON_GOOGLE_ACCOUNT}" == "false" ]]; then
+    ######################################################
+    # Configure the original (non-workbench) proxy agent
+    ######################################################
     emit "Configuring the original Proxy Agent banner for Google account..."
-    # Map the CLI server to the appropriate UI url
-    if [[ "${TERRA_SERVER}" == *"verily"* ]]; then
-      # Map the CLI server to the appropriate UI url
-      if [[ "${TERRA_SERVER}" == "verily" ]]; then
-        UI_BASE_URL="workbench.verily.com"
-      else
-        UI_BASE_URL="${TERRA_SERVER/verily/terra}-ui-terra.api.verily.com"
-      fi
-    else
-      >&2 echo "ERROR: ${TERRA_SERVER} is not a known verily server."
-      exit 1
-    fi
+    UI_BASE_URL=$(get_ui_uri "${TERRA_SERVER}")
     readonly UI_BASE_URL
 
     # The banner.html file contains <style> wrapper tags and a series of CSS styles, and a set of html link elements that we want to modify.
@@ -1122,11 +1181,11 @@ EOF
   sed -i -e "/c.GCSContentsManager/d" -e "/CombinedContentsManager/d" "${JUPYTER_CONFIG}"
   echo "c.FileContentsManager.root_dir = '${USER_HOME_DIR}'" >> "${JUPYTER_CONFIG}"
 
-  if [[ -n "${APP_PROXY}" ]] && [[ "${USE_VWB_PROXY}" == "true" ]]; then
+  if [[ "${PROXY_TYPE}" != "${PROXY_TYPE_GOOGLE}" ]]; then
     cat << EOF >> "${JUPYTER_CONFIG}"
-c.NotebookApp.allow_origin_pat += "|(https?://)?(https://${NEW_PROXY_URL})"
+c.NotebookApp.allow_origin_pat += "|(https?://)?(${APP_PROXY_URL})"
 c.NotebookApp.allow_remote_access= True
-c.NotebookApp.local_hostnames.append('${APP_PROXY}')
+c.NotebookApp.local_hostnames.append('${PROXY_SERVICE_URL}')
 EOF
   fi
   # Add a marker for the Workbench-specific customizations

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -173,7 +173,7 @@ readonly -f emit
 function get_metadata_value() {
   local metadata_path="${1}"
   curl --retry 5 -s -f \
-    -H "Metadata-Flavor: Google" \
+      -H "Metadata-Flavor: Google" \
       "http://metadata/computeMetadata/v1/${metadata_path}" \
     || echo -n
 }
@@ -914,7 +914,7 @@ EOF
     systemctl enable "${WORKBENCH_PROXY_AGENT_SERVICE_NAME}"
     # Start the service in non-blocking mode to allow startup script to continue without waiting
     systemctl --no-block start "${WORKBENCH_PROXY_AGENT_SERVICE_NAME}"
-    emit "Workbench Proxy Agent started"
+    emit "Workbench Proxy Agent service started"
 else
   emit "Using Google Proxy"
 fi
@@ -1129,9 +1129,9 @@ fi
   fi
 
   if [[ "${IS_NON_GOOGLE_ACCOUNT}" == "false" ]]; then
-    ######################################################
-    # Configure the original (non-workbench) proxy agent
-    ######################################################
+  ######################################################
+  # Configure the original (non-workbench) proxy agent
+  ######################################################
     emit "Configuring the original Proxy Agent banner for Google account..."
     UI_BASE_URL=$(get_ui_uri "${TERRA_SERVER}")
     readonly UI_BASE_URL

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -831,8 +831,8 @@ readonly IS_NON_GOOGLE_ACCOUNT
 ENABLE_VWB_PROXY="$(get_metadata_value "instance/attributes/enable-dataproc-vwb-proxy")"
 readonly ENABLE_VWB_PROXY
 # Retrieve Workbench proxy agent image
-PROXY_IMAGE="$(get_metadata_value "instance/attributes/proxy-image")"
-readonly PROXY_IMAGE
+PROXY_AGENT_IMAGE="$(get_metadata_value "instance/attributes/proxy-agent-image")"
+readonly PROXY_AGENT_IMAGE
 APP_PROXY="$(get_app_proxy_uri "${TERRA_SERVER}")"
 readonly APP_PROXY
 RESOURCE_ID="$(get_metadata_value "instance/attributes/terra-resource-id")"
@@ -851,7 +851,7 @@ PROXY_TYPE_GOOGLE_AGENT_WITH_VWB_PROXY="GOOGLE_AGENT_WITH_VWB_PROXY"
 
 # Decide proxy type
 PROXY_TYPE=""
-if [[ ${ENABLE_VWB_PROXY} == "true" && -n "${PROXY_IMAGE}" ]]; then
+if [[ ${ENABLE_VWB_PROXY} == "true" && -n "${PROXY_AGENT_IMAGE}" ]]; then
   PROXY_TYPE="${PROXY_TYPE_VWB}"
 elif [[ ${IS_NON_GOOGLE_ACCOUNT} == "true" ]]; then
   PROXY_TYPE="${PROXY_TYPE_GOOGLE_AGENT_WITH_VWB_PROXY}"
@@ -880,7 +880,7 @@ ExecStart=/bin/bash -c '/usr/bin/docker run \\
       --detach \\
       --name "proxy-agent" \\
       --restart=unless-stopped \\
-      --net=host "${PROXY_IMAGE}" \\
+      --net=host "${PROXY_AGENT_IMAGE}" \\
       --proxy="${PROXY_SERVICE_URL}" \\
       --host="localhost:8123" \\
       --compute-platform="GCP" \\

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -888,7 +888,7 @@ ExecStart=/bin/bash -c '/usr/bin/docker run \\
       --rewrite-websocket-host="true" \\
       --backend="${RESOURCE_ID}" \\
       --session-cookie-name="_xsrf" \\
-      --inject-banner="\$(cat /opt/dataproc/proxy-agent/banner.html)" \\
+      --inject-banner="\$(cat ${PROXY_AGENT_BANNER})" \\
       --enable-monitoring-script="${ENABLE_MONITORING_SCRIPT:-false}"'
 
 [Install]


### PR DESCRIPTION
Corresponding PR: [add config flag for dataproc startup script](https://github.com/verily-src/terra-service-ws-manager/pull/1093)

BENCH-5473

[BENCH-5473]: https://verily.atlassian.net/browse/BENCH-5473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ