### PR TITLE
Dataproc's default logging driver is google cloud logging

### DIFF
--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -915,11 +915,11 @@ a#workspace {\
 fi
 
 # Start Docker proxy agent
+# The data proc proxy agent contain logs are sent to Google Cloud logging.
+# See https://docs.docker.com/engine/logging/drivers/gcplogs/.
 docker start "proxy-agent" 2>/dev/null \
   || docker run \
   --detach \
-  --log-opt max-size=10m \
-  --log-opt max-file=3 \
   --name "proxy-agent" \
   --restart=unless-stopped \
   --net=host "${PROXY_AGENT_IMAGE}" \


### PR DESCRIPTION
https://docs.docker.com/engine/logging/drivers/gcplogs/