### PR TITLE
Fix docker-compose command when caching app sidecar

### DIFF
--- a/startupscript/butane/prepare-devcontainer-cache.sh
+++ b/startupscript/butane/prepare-devcontainer-cache.sh
@@ -7,6 +7,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export PATH="/opt/bin:$PATH"
+
 function usage {
   echo "Usage: $0 [-d path] [image...]"
   echo "  -d path: optionally provide a path to a docker-compose directory to build."
@@ -54,7 +56,7 @@ if [[ -n "${DOCKER_DIR+x}" ]]; then
     # Build all sidecars
     pushd "${DOCKER_DIR}"
     while IFS='' read -r service; do
-        docker compose build "${service}"
+        docker-compose build "${service}"
     done < <(docker-compose config --services | sed '/^app$/d')
     popd
 fi


### PR DESCRIPTION
It couldn't find the docker-compose command. Other startup scripts add `/opt/bin` to `PATH` as well, so that's what we'll do here