### PR TITLE
Pin remotefuse to Debian 12

### DIFF
--- a/src/jupyter-aou/remotefuse/Dockerfile
+++ b/src/jupyter-aou/remotefuse/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:12-slim
 
 RUN apt-get update --yes && \
     apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
gcsfuse isn't available for Debian 13 yet