### PR TITLE
Fix docker credentials helper script.

### DIFF
--- a/startupscript/butane/aws/credential-helper.sh
+++ b/startupscript/butane/aws/credential-helper.sh
@@ -88,9 +88,12 @@ case "${COMMAND}" in
         ;;
 
     get)
-        # 'docker pull' or 'docker push' calls this command.
-        # It reads the server URL from stdin.
-        read -r server_url
+        # 'docker pull' or 'docker push' calls this command. It reads the server
+        # URL from stdin.  Note that when called from the docker daemon, the
+        # daemon will close the pipe immediately. This will result in the read
+        # command returning a non-zero status despite the input being available.
+        # We handle this by using '|| true' to allow the script to continue.
+        read -r server_url || true
         get_credentials "${server_url}"
         ;;
 


### PR DESCRIPTION
Fix docker credentials helper script, which fails when called by the docker daemon since it aggressively closes the pipe to stdin, causing the `read` bash buitin to return non-zero despite receiving all input data.