### PR TITLE
Enable installFromSource for workbench-tools feature in GCP apps

### DIFF
--- a/features/src/workbench-tools/NOTES.md
+++ b/features/src/workbench-tools/NOTES.md
@@ -12,4 +12,4 @@
 - *VEP==114.2
 
 _*: These need to be built from source and will only be included if
-`installFromSource` is set to `true`._
+`installFromSource` is set to `true` or `cloud` is set to `gcp`._

--- a/features/src/workbench-tools/README.md
+++ b/features/src/workbench-tools/README.md
@@ -15,6 +15,7 @@ Installs common tools for Workbench Apps. Currently it only supports Debian-base
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
+| cloud | Cloud provider to install CLI tools for. If set to \"gcp\", installFromSource will default to true. | string | "" |
 | installFromSource | Install tools that require building from source. This may take a long time. | boolean | false |
 
 ## Versions
@@ -31,7 +32,7 @@ Installs common tools for Workbench Apps. Currently it only supports Debian-base
 - *VEP==114.2
 
 _*: These need to be built from source and will only be included if
-`installFromSource` is set to `true`._
+`installFromSource` is set to `true` or `cloud` is set to `gcp`._
 
 
 ---

--- a/features/src/workbench-tools/devcontainer-feature.json
+++ b/features/src/workbench-tools/devcontainer-feature.json
@@ -4,6 +4,11 @@
   "name": "Workbench Tools",
   "description": "Installs common tools for Workbench Apps. Currently it only supports Debian-based systems (e.g. Ubuntu) on x86_64.",
   "options": {
+      "cloud": {
+          "type": "string",
+          "default": "",
+          "description": "Cloud provider to install CLI tools for. If set to \"gcp\", installFromSource will default to true."
+      },
       "installFromSource": {
         "type": "boolean",
         "default": false,

--- a/features/src/workbench-tools/install.sh
+++ b/features/src/workbench-tools/install.sh
@@ -8,7 +8,12 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-readonly INSTALL_FROM_SOURCE="${INSTALLFROMSOURCE:-"false"}"
+readonly CLOUD="${CLOUD:-""}"
+INSTALL_FROM_SOURCE="${INSTALLFROMSOURCE:-"false"}"
+if [[ "$CLOUD" = "gcp" ]]; then
+    INSTALL_FROM_SOURCE="true"
+fi
+readonly INSTALL_FROM_SOURCE
 
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC

--- a/src/custom-workbench-jupyter-template/.devcontainer.json
+++ b/src/custom-workbench-jupyter-template/.devcontainer.json
@@ -20,7 +20,9 @@
     "${templateOption:login}"
   ],
   "features": {
-    "./.devcontainer/features/workbench-tools": {}
+    "./.devcontainer/features/workbench-tools": {
+      "cloud": "${templateOption:cloud}"
+    }
   },
   "remoteUser": "root",
   "customizations": {

--- a/src/jupyter-aou/.devcontainer.json
+++ b/src/jupyter-aou/.devcontainer.json
@@ -9,7 +9,9 @@
   // re-mount bucket files on container start up
   "postStartCommand": "./startupscript/remount-on-restart.sh jupyter /home/jupyter \"${templateOption:cloud}\" \"${templateOption:login}\"",
   "features": {
-    "./.devcontainer/features/workbench-tools": {}
+    "./.devcontainer/features/workbench-tools": {
+      "cloud": "${templateOption:cloud}"
+    }
   },
   "remoteUser": "root",
   "customizations": {

--- a/src/r-analysis/.devcontainer.json
+++ b/src/r-analysis/.devcontainer.json
@@ -29,7 +29,9 @@
     },
     "ghcr.io/devcontainers/features/aws-cli@sha256:bbc9fd513c22e331953126c75ad7b2ed1f9044f1cd5890b7073b634810459b18": {},
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
-    "./.devcontainer/features/workbench-tools": {}
+    "./.devcontainer/features/workbench-tools": {
+      "cloud": "${templateOption:cloud}"
+    }
   },
   "remoteUser": "root"
 }

--- a/src/vscode/.devcontainer.json
+++ b/src/vscode/.devcontainer.json
@@ -20,7 +20,9 @@
     },
     "ghcr.io/devcontainers/features/aws-cli@sha256:bbc9fd513c22e331953126c75ad7b2ed1f9044f1cd5890b7073b634810459b18": {},
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
-    "./.devcontainer/features/workbench-tools": {}
+    "./.devcontainer/features/workbench-tools": {
+      "cloud": "${templateOption:cloud}"
+    }
   },
   "remoteUser": "root",
   "customizations": {


### PR DESCRIPTION
Adds a new cloud parameter to specify the cloud the app is running on. If the cloud is "gcp", installFromSource will default to true for workbench-tools.

PHP-71105