### PR TITLE
Set WORKBENCH_INSTALL_PATH when remounting after container restart

### DIFF
--- a/startupscript/remount-on-restart.sh
+++ b/startupscript/remount-on-restart.sh
@@ -14,6 +14,9 @@ if [[ $# -ne 4 ]]; then
   exit 1
 fi
 
+readonly WORKBENCH_INSTALL_PATH="${WORKBENCH_INSTALL_PATH:-/usr/bin/wb}"
+export WORKBENCH_INSTALL_PATH
+
 readonly USER_NAME="${1}"
 readonly WORK_DIRECTORY="${2}"
 readonly CLOUD="${3}"

--- a/startupscript/remount-on-restart.sh
+++ b/startupscript/remount-on-restart.sh
@@ -15,7 +15,6 @@ if [[ $# -ne 4 ]]; then
 fi
 
 readonly WORKBENCH_INSTALL_PATH="${WORKBENCH_INSTALL_PATH:-/usr/bin/wb}"
-export WORKBENCH_INSTALL_PATH
 
 readonly USER_NAME="${1}"
 readonly WORK_DIRECTORY="${2}"


### PR DESCRIPTION
remount-on-restart assumes WORKBENCH_INSTALL_PATH is set which is not true when the container is restarting after a prior create