### PR TITLE
Delete wb container after it exits

### DIFF
--- a/startupscript/butane/wb/wb.sh
+++ b/startupscript/butane/wb/wb.sh
@@ -26,6 +26,7 @@ source '/home/core/wb/values.sh'
 # - Volume mount for persistence (-v)
 # - Pass all script arguments to container ("${@}")
 docker run \
+    --rm \
     --network host \
     -v "${WB_CONTEXT_DIR}:/workbench_context:rw" \
     "${WB_IMAGE_NAME}" "${@}"


### PR DESCRIPTION
The `wb` script currently doesn't delete the container after it exits, leading to something like this:

<img width="1032" height="489" alt="image" src="https://github.com/user-attachments/assets/80bb920e-05d8-41ff-b548-600400611592" />
