### PR TITLE
docs(readme): fix example app link (wrong repo name + branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you need more control, you can manually create a custom app:
    - Run the test script: `cd test && ./test.sh <your-app-name>`
    - Create a custom app in Workbench UI pointing to your forked repo and branch
 
-6. **Reference the example app** at [src/example](https://github.com/verily-src/workbench-app-devcontainer/tree/main/src/example) to see a basic implementation
+6. **Reference the example app** at [src/example](https://github.com/verily-src/workbench-app-devcontainers/tree/master/src/example) to see a basic implementation
 
 For detailed guidance, visit https://support.workbench.verily.com/docs/guides/cloud_apps/create_custom_apps/
 


### PR DESCRIPTION
## Summary

README's *Reference the example app* step (line 114) linked to:

\`\`\`
https://github.com/verily-src/workbench-app-devcontainer/tree/main/src/example
\`\`\`

Two bugs:
- repo name is missing its trailing 's' (\`workbench-app-devcontainer\` vs. the actual \`workbench-app-devcontainers\`)
- branch is 'main' but this repo's default branch is 'master'

Fixed to:
\`\`\`
https://github.com/verily-src/workbench-app-devcontainers/tree/master/src/example
\`\`\`

Closes #340

## Testing

Docs-only change. Verified \`src/example\` exists on master.