### PR TITLE
Temporarily turn off xtrace when passing auth tokens

### DIFF
--- a/startupscript/butane/monitoring-utils.sh
+++ b/startupscript/butane/monitoring-utils.sh
@@ -15,6 +15,11 @@ function log_event() {
     local payload="$4"
     local log_url="${wsm_url}/api/workspaces/v1/${workspace_id}/resources/${resource_id}/instance-state"
 
+    if [[ $- == *x* ]]; then
+        { set +o xtrace; } 2>/dev/null
+        trap 'set -o xtrace' RETURN
+    fi
+
     # Log VM event
     local response
     response=$(curl -s -X POST "${log_url}" \

--- a/startupscript/butane/probe-proxy-readiness.sh
+++ b/startupscript/butane/probe-proxy-readiness.sh
@@ -33,8 +33,10 @@ if docker ps -q --filter "name=proxy-agent" | grep -q . \
         WORKSPACE_USER_FACING_ID="$(get_metadata_value "terra-workspace-id" "")"
         SERVER="$(get_metadata_value "terra-cli-server" "prod")"
         WSM_SERVICE_URL="$(get_service_url "wsm" "${SERVER}")"
+        set +o xtrace
         RESPONSE=$(curl -s -X GET "${WSM_SERVICE_URL}/api/workspaces/v1/workspaceByUserFacingId/${WORKSPACE_USER_FACING_ID}" \
                     -H "Authorization: Bearer $(/home/core/wb.sh auth print-access-token)")
+        set -o xtrace
         WORKSPACE_ID=$(echo "${RESPONSE}" | jq -r '.id');
         RESOURCE_ID="$(get_metadata_value "wb-resource-id" "")"
 

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -962,9 +962,11 @@ chown "${LOGIN_USER}:${LOGIN_USER}" "${USER_BASHRC}"
 chown "${LOGIN_USER}:${LOGIN_USER}" "${USER_BASH_PROFILE}"
 
 # TODO(BENCH-2612): use workbench CLI instead to get user profile.
+set +o xtrace
 IS_NON_GOOGLE_ACCOUNT="$(curl "${USER_SERVICE_URL}/api/profile?path=non_google_account" \
                     -H "accept: application/json" -H "Authorization: Bearer $(gcloud auth print-access-token)" \
                   | jq '.value')"
+set -o xtrace
 readonly IS_NON_GOOGLE_ACCOUNT
 
 # Retrieve Workbench proxy agent image

--- a/startupscript/setup-docker.sh
+++ b/startupscript/setup-docker.sh
@@ -42,4 +42,6 @@ usermod -aG docker jupyter
 chown -R jupyter /home/jupyter/.docker
 
 # Login to docker with gcloud credentials (needs to be re-run every 30 min if needed)
+set +o xtrace
 sudo -u jupyter /bin/bash -c "docker login -u oauth2accesstoken -p $(gcloud auth print-access-token) https://us-central1-docker.pkg.dev"
+set -o xtrace

--- a/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
+++ b/startupscript/vertex-ai-user-managed-notebook/post-startup.sh
@@ -851,9 +851,11 @@ if [[ -n "${USER_STARTUP_SCRIPT}" ]]; then
 fi
 
 # TODO(BENCH-2612): use workbench CLI instead to get user profile.
+set +o xtrace
 IS_NON_GOOGLE_ACCOUNT="$(curl "${USER_SERVICE_URL}/api/profile?path=non_google_account" \
                     -H "accept: application/json" -H "Authorization: Bearer $(gcloud auth print-access-token)" \
                   | jq '.value')"
+set -o xtrace
 readonly IS_NON_GOOGLE_ACCOUNT
 
 if [[ "${IS_NON_GOOGLE_ACCOUNT}" == "true" ]]; then


### PR DESCRIPTION
So the tokens aren't leaked in logs