### PR TITLE
Add dbm-example custom Jupyter app template

### DIFF
--- a/src/dbm-example/.devcontainer.json
+++ b/src/dbm-example/.devcontainer.json
@@ -13,8 +13,8 @@
   ],
   "postStartCommand": [
     "./startupscript/remount-on-restart.sh",
-    "rishbahc",
-    "/home/rishabhc",
+    "jovyan",
+    "/home/jovyan",
     "${templateOption:cloud}",
     "${templateOption:login}"
   ],

--- a/src/dbm-example/.devcontainer.json
+++ b/src/dbm-example/.devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "dbm-example",
+  "dockerComposeFile": "docker-compose.yaml",
+  "service": "app",
+  "shutdownAction": "none",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": [
+    "./startupscript/post-startup.sh",
+    "rishbahc",
+    "/home/rishabhc",
+    "${templateOption:cloud}",
+    "${templateOption:login}"
+  ],
+  "postStartCommand": [
+    "./startupscript/remount-on-restart.sh",
+    "rishbahc",
+    "/home/rishabhc",
+    "${templateOption:cloud}",
+    "${templateOption:login}"
+  ],
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "17"
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/dhoeric/features/google-cloud-cli:1": {}
+  },
+  "remoteUser": "root"
+}

--- a/src/dbm-example/.devcontainer.json
+++ b/src/dbm-example/.devcontainer.json
@@ -6,8 +6,8 @@
   "workspaceFolder": "/workspace",
   "postCreateCommand": [
     "./startupscript/post-startup.sh",
-    "rishbahc",
-    "/home/rishabhc",
+    "jovyan",
+    "/home/jovyan",
     "${templateOption:cloud}",
     "${templateOption:login}"
   ],

--- a/src/dbm-example/README.md
+++ b/src/dbm-example/README.md
@@ -1,0 +1,43 @@
+# dbm-example
+
+Custom Workbench application based on quay.io/jupyter/base-notebook.
+
+## Configuration
+
+- **Image**: quay.io/jupyter/base-notebook
+- **Port**: 8888
+- **User**: rishbahc
+- **Home Directory**: /home/rishabhc
+
+## Access
+
+Once deployed in Workbench, access your terminal at the app URL (port 8888).
+
+For local testing:
+1. Create Docker network: `docker network create app-network`
+2. Run the app: `devcontainer up --workspace-folder .`
+3. Access at: `http://localhost:8888`
+
+## Customization
+
+Edit the following files to customize your app:
+
+- `.devcontainer.json` - Devcontainer configuration and features
+- `docker-compose.yaml` - Docker Compose configuration (change the `command` to customize ttyd options)
+- `devcontainer-template.json` - Template options and metadata
+
+## Testing
+
+To test this app template:
+
+```bash
+cd test
+./test.sh dbm-example
+```
+
+## Usage
+
+1. Fork the repository
+2. Modify the configuration files as needed
+3. In Workbench UI, create a custom app pointing to your forked repository
+4. Select this app template (dbm-example)

--- a/src/dbm-example/README.md
+++ b/src/dbm-example/README.md
@@ -6,8 +6,8 @@ Custom Workbench application based on quay.io/jupyter/base-notebook.
 
 - **Image**: quay.io/jupyter/base-notebook
 - **Port**: 8888
-- **User**: rishbahc
-- **Home Directory**: /home/rishabhc
+- **User**: rishabhc
+- **Home Directory**: /home/jovyan
 
 ## Access
 

--- a/src/dbm-example/devcontainer-template.json
+++ b/src/dbm-example/devcontainer-template.json
@@ -1,0 +1,20 @@
+{
+  "id": "dbm-example",
+  "version": "1.0.0",
+  "name": "dbm-example",
+  "description": "Custom Workbench app: dbm-example (Image: quay.io/jupyter/base-notebook, Port: 8888, User: rishbahc)",
+  "options": {
+    "cloud": {
+      "type": "string",
+      "enum": ["gcp", "aws"],
+      "default": "gcp",
+      "description": "Cloud provider (gcp or aws)"
+    },
+    "login": {
+      "type": "string",
+      "description": "Whether to log in to workbench CLI",
+      "proposals": ["true", "false"],
+      "default": "false"
+    }
+  }
+}

--- a/src/dbm-example/docker-compose.yaml
+++ b/src/dbm-example/docker-compose.yaml
@@ -1,0 +1,36 @@
+services:
+  app:
+    # The container name must be "application-server"
+    container_name: "application-server"
+    # This can be either a pre-existing image or built from a Dockerfile
+    image: "quay.io/jupyter/base-notebook"
+    # build:
+    #   context: .
+    restart: always
+    volumes:
+      - .:/workspace:cached
+      - work:/home/rishabhc/work
+    # The port specified here will be forwarded and accessible from the
+    # Workbench UI.
+    ports:
+      - 8888:8888
+    # The service must be connected to the "app-network" Docker network
+    networks:
+      - app-network
+    # SYS_ADMIN and fuse are required to mount workspace resources into the
+    # container.
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
+
+volumes:
+  work:
+
+networks:
+  # The Docker network must be named "app-network". This is an external network
+  # that is created outside of this docker-compose file.
+  app-network:
+    external: true

--- a/src/dbm-example/docker-compose.yaml
+++ b/src/dbm-example/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     restart: always
     volumes:
       - .:/workspace:cached
-      - work:/home/rishabhc/work
+      - work:/home/jovyan/work
     # The port specified here will be forwarded and accessible from the
     # Workbench UI.
     ports:

--- a/tests/dbm-example.sh
+++ b/tests/dbm-example.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -o errexit
+export TEST_USER="jovyan"
+export TEST_USER_HOME="/home/jovyan"
+
+bats tests/common/base.bats


### PR DESCRIPTION
## Summary
- Adds new custom app template `dbm-example` based on Jupyter base-notebook
- Includes Workbench tools (gcsfuse, wb CLI) and cloud CLIs (AWS, GCP)
- Configured with Java 17 support
- User: rishbahc, Home: /home/rishabhc, Port: 8888

## Test plan
- [x] Local build and test with Docker Desktop
- [x] All BATS tests passing (gcsfuse, wb CLI, fuse.conf)
- [x] Jupyter Lab accessible on port 8888
- [ ] Test in Workbench UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)