### PR TITLE
Fluent-bit send application-server logs only

### DIFF
--- a/startupscript/butane/aws/fluent-bit.conf
+++ b/startupscript/butane/aws/fluent-bit.conf
@@ -39,6 +39,11 @@
     Mem_Buf_Limit 10MB
     Refresh_Interval 5
 
+[FILTER]
+    Name grep
+    Match vm.docker
+    Regex log "tag":"application-server"
+
 [OUTPUT]
     Name cloudwatch_logs
     Match vm.*

--- a/startupscript/butane/gcp/fluent-bit.conf
+++ b/startupscript/butane/gcp/fluent-bit.conf
@@ -39,6 +39,11 @@
     Mem_Buf_Limit 10MB
     Refresh_Interval 5
 
+[FILTER]
+    Name grep
+    Match vm.docker
+    Regex log "tag":"application-server"
+
 [OUTPUT]
     name stackdriver
     match vm.*


### PR DESCRIPTION
Exclude logs from other containers, e.g. app-proxy, fluent-bit