### PR TITLE
Fluent-bit configure log severity

### DIFF
--- a/startupscript/butane/aws/fluent-bit.conf
+++ b/startupscript/butane/aws/fluent-bit.conf
@@ -39,6 +39,12 @@
     Mem_Buf_Limit 10MB
     Refresh_Interval 5
 
+[FILTER]
+    Name    lua
+    Match   vm.*
+    script  /fluent-bit/scripts/severity.lua
+    call    set_severity
+
 [OUTPUT]
     Name cloudwatch_logs
     Match vm.*

--- a/startupscript/butane/gcp/fluent-bit.conf
+++ b/startupscript/butane/gcp/fluent-bit.conf
@@ -39,7 +39,14 @@
     Mem_Buf_Limit 10MB
     Refresh_Interval 5
 
+[FILTER]
+    Name    lua
+    Match   vm.*
+    script  /fluent-bit/scripts/severity.lua
+    call    set_severity
+
 [OUTPUT]
     name stackdriver
     match vm.*
     resource gce_instance
+    severity_key severity

--- a/startupscript/butane/run-fluent-bit.sh
+++ b/startupscript/butane/run-fluent-bit.sh
@@ -52,6 +52,7 @@ DOCKER_ARGS=(
     --name fluent-bit
     --network host
     -v /etc/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+    -v /etc/fluent-bit/severity.lua:/fluent-bit/scripts/severity.lua:ro
     -v /var/log/journal:/var/log/journal:ro
     -v /var/lib/docker/containers:/var/lib/docker/containers:ro
     -v /var/lib/fluent-bit:/var/lib/fluent-bit

--- a/startupscript/butane/severity.lua
+++ b/startupscript/butane/severity.lua
@@ -1,0 +1,33 @@
+function set_severity(tag, timestamp, record)
+    local priority = record["PRIORITY"]
+
+    if priority then
+        -- Journald logs: map syslog priority (0-7) to severity levels
+        local p = tostring(priority)
+
+        if p == "0" then
+            record["severity"] = "EMERGENCY"
+        elseif p == "1" then
+            record["severity"] = "ALERT"
+        elseif p == "2" then
+            record["severity"] = "CRITICAL"
+        elseif p == "3" then
+            record["severity"] = "ERROR"
+        elseif p == "4" then
+            record["severity"] = "WARNING"
+        elseif p == "5" then
+            record["severity"] = "NOTICE"
+        elseif p == "6" then
+            record["severity"] = "INFO"
+        elseif p == "7" then
+            record["severity"] = "DEBUG"
+        else
+            record["severity"] = "INFO"
+        end
+    else
+        -- No priority field (e.g., Docker logs), default to INFO
+        record["severity"] = "INFO"
+    end
+
+    return 1, timestamp, record
+end

--- a/startupscript/butane/severity.lua
+++ b/startupscript/butane/severity.lua
@@ -4,6 +4,7 @@ function set_severity(tag, timestamp, record)
     if priority then
         -- Journald logs: map syslog priority (0-7) to severity levels
         local p = tostring(priority)
+        record["severity_level"] = tonumber(priority)
 
         if p == "0" then
             record["severity"] = "EMERGENCY"
@@ -27,6 +28,7 @@ function set_severity(tag, timestamp, record)
     else
         -- No priority field (e.g., Docker logs), default to INFO
         record["severity"] = "INFO"
+        record["severity_level"] = 6
     end
 
     return 1, timestamp, record


### PR DESCRIPTION
Severity isn't setup properly on the exported log entires.
Add a severity field to set the GCP Cloud Logs severity properly.
AWS Cloudwatch does not have an inherent severity. Add a severity field for log filtering from the UI or CLI.

Introduced both a "severity" field and "severity_level" field. "severity" field is needed for GCP cloud logs to understand what severity the log entry should appear as. "severity_level" is used for filtering by severity level.