### PR TITLE
Skip providing secrets if pipe does not exist

### DIFF
--- a/src/test-app-secrets/secrets.yml
+++ b/src/test-app-secrets/secrets.yml
@@ -1,10 +1,5 @@
 secrets:
   - name: "example-secret"
-    valueVar: "EXAMPLE_SECRET"
-  - name: "pipe-secret"
-    pipeVar: "PIPE_SECRET"
-  - name: "path-secret"
-    pathVar: "PATH_SECRET"
-  - name: "multi-dest-secret"
-    valueVar: "MULTI_VALUE"
-    pathVar: "MULTI_PATH"
+    valueVar: "SECRET_VALUE"
+    pathVar: "SECRET_PATH"
+    pipeVar: "SECRET_PIPE"

--- a/startupscript/butane/055-provide-secrets.sh
+++ b/startupscript/butane/055-provide-secrets.sh
@@ -126,15 +126,10 @@ readonly ATTACHED_SECRETS
 
 echo "Waiting for container to create named pipe..."
 
-retries=0
-until docker exec "${CONTAINER_NAME}" sh -c "[ -p ${PIPE_PATH} ]" 2>/dev/null; do
-  if (( retries >= 40 )); then
-    >&2 echo "ERROR: Timed out waiting for container to create ${PIPE_PATH}"
-    exit 1
-  fi
-  sleep 3
-  (( retries++ ))
-done
+if ! docker exec "${CONTAINER_NAME}" sh -c "[ -p ${PIPE_PATH} ]" 2>/dev/null; then
+  >&2 echo "Container not receinv secrets at ${PIPE_PATH}. Skipping secret provisioning."
+  exit 0
+fi
 
 # --- Build JSON secrets array for pipe delivery ---
 SECRETS_JSON="[]"

--- a/tests/test-app-secrets.bats
+++ b/tests/test-app-secrets.bats
@@ -15,25 +15,25 @@ get_pid1_env() {
     ! exec_in_container root test -e /tmp/secrets
 }
 
-@test "secret: EXAMPLE_SECRET has correct value" {
-    result="$(get_pid1_env EXAMPLE_SECRET)"
-    [ "$result" = "test-value-secret" ]
+@test "secret: SECRET_VALUE has correct value" {
+    result="$(get_pid1_env SECRET_VALUE)"
+    [ "$result" = "secret-value" ]
 }
 
-@test "secret: PIPE_SECRET fd can only be read once" {
-    fd_path="$(get_pid1_env PIPE_SECRET)"
+@test "secret: SECRET_PIPE fd can only be read once" {
+    fd_path="$(get_pid1_env SECRET_PIPE)"
     fd="${fd_path#/dev/fd/}"
     result="$(exec_in_container root cat "/proc/1/fd/${fd}")"
-    [ "$result" = "test-pipe-secret" ]
+    [ "$result" = "secret-value" ]
     result="$(exec_in_container root cat "/proc/1/fd/${fd}")"
     [ "$result" = "" ]
 }
 
-@test "secret: PATH_SECRET fd is readable multiple times" {
-    fd_path="$(get_pid1_env PATH_SECRET)"
+@test "secret: SECRET_PATH fd is readable multiple times" {
+    fd_path="$(get_pid1_env SECRET_PATH)"
     fd="${fd_path#/dev/fd/}"
     result="$(exec_in_container root cat "/proc/1/fd/${fd}")"
-    [ "$result" = "test-path-secret" ]
+    [ "$result" = "secret-value" ]
     result="$(exec_in_container root cat "/proc/1/fd/${fd}")"
-    [ "$result" = "test-path-secret" ]
+    [ "$result" = "secret-value" ]
 }

--- a/tests/test-app-secrets.sh
+++ b/tests/test-app-secrets.sh
@@ -16,11 +16,9 @@ fi
 # Inject mock secrets to unblock the secret receiver
 echo "Injecting mock secrets..."
 echo '[
-    {"type":"valueVar","value":"test-value-secret","target":"EXAMPLE_SECRET"},
-    {"type":"pipeVar","value":"test-pipe-secret","target":"PIPE_SECRET"},
-    {"type":"pathVar","value":"test-path-secret","target":"PATH_SECRET"},
-    {"type":"valueVar","value":"test-multi-secret","target":"MULTI_VALUE"},
-    {"type":"pathVar","value":"test-multi-secret","target":"MULTI_PATH"}
+    {"type":"valueVar","value":"secret-value","target":"SECRET_VALUE"},
+    {"type":"pathVar","value":"secret-value","target":"SECRET_PATH"}
+    {"type":"pipeVar","value":"secret-value","target":"SECRET_PIPE"}
 ]' | timeout 30 docker exec --user root -i "$CONTAINER_NAME" sh -c 'cat > /tmp/secrets'
 
 bats tests/test-app-secrets.bats

--- a/tests/test-app-secrets.sh
+++ b/tests/test-app-secrets.sh
@@ -17,7 +17,7 @@ fi
 echo "Injecting mock secrets..."
 echo '[
     {"type":"valueVar","value":"secret-value","target":"SECRET_VALUE"},
-    {"type":"pathVar","value":"secret-value","target":"SECRET_PATH"}
+    {"type":"pathVar","value":"secret-value","target":"SECRET_PATH"},
     {"type":"pipeVar","value":"secret-value","target":"SECRET_PIPE"}
 ]' | timeout 30 docker exec --user root -i "$CONTAINER_NAME" sh -c 'cat > /tmp/secrets'
 


### PR DESCRIPTION
Otherwise restarting the devcontainer service will fail since the existing app no longer listens for secrets.

We shouldn't need to wait anyways since the docker container should've already started with devcontainer up, and it should create the pipe almost instantly.