### PR TITLE
Add early access CDR config and GAR for AoU data collections

### DIFF
--- a/src/aou-common/load-envs/configs/cdr_config_early_access.json
+++ b/src/aou-common/load-envs/configs/cdr_config_early_access.json
@@ -1,0 +1,31 @@
+{
+  "accessTiers": [
+    {
+      "shortName": "registered",
+      "datasetsBucket": "",
+      "artifactRegistryRepo": "us-central1-docker.pkg.dev/all-of-us-rw-prod/aou-rw-gar-remote-repo-docker-prod"
+    },
+    {
+      "shortName": "controlled",
+      "datasetsBucket": "gs://vwb-aou-earlyaccess-datasets-controlled/",
+      "artifactRegistryRepo": "us-central1-docker.pkg.dev/all-of-us-rw-prod/aou-rw-gar-remote-repo-docker-prod"
+    }
+  ],
+  "cdrVersions": [
+    {
+      "name": "All of Us Registered Tier Early Access Dataset v9",
+      "bigqueryProject": "wb-crisp-citrus-2555",
+      "bigqueryDataset": "R2025Q4R4",
+      "accessTier": "registered",
+      "dcVersionName": "cdrv9-ea"
+    },
+    {
+      "name": "All of Us Controlled Tier Early Access Dataset v9",
+      "bigqueryProject": "wb-bright-olive-4015",
+      "bigqueryDataset": "C2025Q4R3",
+      "accessTier": "controlled",
+      "storageBasePath": "v9",
+      "dcVersionName": "cdrv9-ea"
+    }
+  ]
+}

--- a/src/aou-common/load-envs/configs/cdr_config_early_access.json
+++ b/src/aou-common/load-envs/configs/cdr_config_early_access.json
@@ -25,6 +25,21 @@
       "bigqueryDataset": "C2025Q4R3",
       "accessTier": "controlled",
       "storageBasePath": "v9",
+      "wgsCramManifestPath": "wgs/cram/manifest.csv",
+      "microarrayHailStoragePath": "microarray/hail.mt",
+      "microarrayVcfManifestPath": "microarray/vcf/manifest.csv",
+      "microarrayIdatManifestPath": "microarray/idat/manifest.csv",
+      "wgsVdsPath": "wgs/short_read/snpindel/vds/hail.vds",
+      "wgsExomeMultiHailPath": "wgs/short_read/snpindel/exome/multiMT/hail.mt",
+      "wgsExomeSplitHailPath": "wgs/short_read/snpindel/exome/splitMT/hail.mt",
+      "wgsExomeVcfPath": "wgs/short_read/snpindel/exome/vcf",
+      "wgsAcafThresholdMultiHailPath": "wgs/short_read/snpindel/acaf_threshold/multiMT/hail.mt",
+      "wgsAcafThresholdSplitHailPath": "wgs/short_read/snpindel/acaf_threshold/splitMT/hail.mt",
+      "wgsAcafThresholdVcfPath": "wgs/short_read/snpindel/acaf_threshold/vcf",
+      "wgsClinvarMultiHailPath": "wgs/short_read/snpindel/clinvar/multiMT/hail.mt",
+      "wgsClinvarSplitHailPath": "wgs/short_read/snpindel/clinvar/splitMT/hail.mt",
+      "wgsClinvarVcfPath": "wgs/short_read/snpindel/clinvar/vcf",
+      "wgsCMRGVcfPath": "wgs/short_read/snpindel/cmrg",
       "dcVersionName": "cdrv9-ea"
     }
   ]

--- a/src/aou-common/load-envs/configs/cdr_config_early_access.json
+++ b/src/aou-common/load-envs/configs/cdr_config_early_access.json
@@ -17,7 +17,7 @@
       "bigqueryProject": "wb-crisp-citrus-2555",
       "bigqueryDataset": "R2025Q4R4",
       "accessTier": "registered",
-      "dcVersionName": "cdrv9-ea"
+      "dcVersionName": "cdrv9"
     },
     {
       "name": "All of Us Controlled Tier Early Access Dataset v9",
@@ -25,22 +25,11 @@
       "bigqueryDataset": "C2025Q4R3",
       "accessTier": "controlled",
       "storageBasePath": "v9",
-      "wgsCramManifestPath": "wgs/cram/manifest.csv",
-      "microarrayHailStoragePath": "microarray/hail.mt",
-      "microarrayVcfManifestPath": "microarray/vcf/manifest.csv",
-      "microarrayIdatManifestPath": "microarray/idat/manifest.csv",
       "wgsVdsPath": "wgs/short_read/snpindel/vds/hail.vds",
-      "wgsExomeMultiHailPath": "wgs/short_read/snpindel/exome/multiMT/hail.mt",
       "wgsExomeSplitHailPath": "wgs/short_read/snpindel/exome/splitMT/hail.mt",
-      "wgsExomeVcfPath": "wgs/short_read/snpindel/exome/vcf",
       "wgsAcafThresholdMultiHailPath": "wgs/short_read/snpindel/acaf_threshold/multiMT/hail.mt",
       "wgsAcafThresholdSplitHailPath": "wgs/short_read/snpindel/acaf_threshold/splitMT/hail.mt",
-      "wgsAcafThresholdVcfPath": "wgs/short_read/snpindel/acaf_threshold/vcf",
-      "wgsClinvarMultiHailPath": "wgs/short_read/snpindel/clinvar/multiMT/hail.mt",
-      "wgsClinvarSplitHailPath": "wgs/short_read/snpindel/clinvar/splitMT/hail.mt",
-      "wgsClinvarVcfPath": "wgs/short_read/snpindel/clinvar/vcf",
-      "wgsCMRGVcfPath": "wgs/short_read/snpindel/cmrg",
-      "dcVersionName": "cdrv9-ea"
+      "dcVersionName": "cdrv9"
     }
   ]
 }

--- a/src/aou-common/load-envs/configs/configs.go
+++ b/src/aou-common/load-envs/configs/configs.go
@@ -13,3 +13,6 @@ var CdrConfigStable []byte
 
 //go:embed cdr_config_prod.json
 var CdrConfigProd []byte
+
+//go:embed cdr_config_early_access.json
+var CdrConfigEarlyAccess []byte

--- a/src/aou-common/load-envs/configs/datacollection_mapping.json
+++ b/src/aou-common/load-envs/configs/datacollection_mapping.json
@@ -28,5 +28,15 @@
     "dataCollectionUuid": "3d83ef80-77d7-43e8-a479-52946619b769",
     "cdrEnv": "prod",
     "accessTier": "controlled"
+  },
+  {
+    "dataCollectionUuid": "f5a74661-3f8a-4017-85b9-0ebb68dd9718",
+    "cdrEnv": "early_access",
+    "accessTier": "registered"
+  },
+  {
+    "dataCollectionUuid": "e7cff64a-5bd0-4c14-a801-a97401a6822f",
+    "cdrEnv": "early_access",
+    "accessTier": "controlled"
   }
 ]

--- a/src/aou-common/load-envs/main.go
+++ b/src/aou-common/load-envs/main.go
@@ -117,6 +117,8 @@ func GetCdrConfiguration(mappings map[uuid.UUID]DataCollectionMapping, aouVersio
 		cdrConfigData = configs.CdrConfigStable
 	case "prod":
 		cdrConfigData = configs.CdrConfigProd
+	case "early_access":
+		cdrConfigData = configs.CdrConfigEarlyAccess
 	default:
 		return nil, nil, fmt.Errorf("unknown CDR environment: %s", mapping.CdrEnv)
 	}


### PR DESCRIPTION
## Summary
- Adds `cdr_config_early_access.json` with registered tier (wb-crisp-citrus-2555, R2025Q4R4) and controlled tier (wb-bright-olive-4015, C2025Q4R3) entries
- Maps two new data collection UUIDs to the `early_access` cdrEnv in `datacollection_mapping.json`
- Wires up the new config in `configs.go` (embed) and `main.go` (switch case)

## Test plan
- [ ] Verify `go build ./...` passes in `src/aou-common/load-envs`
- [ ] Verify a workspace linked to the early access data collections resolves the correct CDR config
- [ ] Confirm env vars are correctly exported for both registered and controlled tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

PHP-148755