### PR TITLE
Add health check for SAS app readiness

### DIFF
--- a/src/aou-sas/Dockerfile
+++ b/src/aou-sas/Dockerfile
@@ -78,6 +78,12 @@ RUN PROXY_CONF=/etc/httpd/conf.d/dkrapro-proxy.conf && \
 ###############################################################################
 RUN mkdir -p /data && chown aou:aougroup /data
 
+# SAS Studio takes ~40s to start inside the container.  The Docker
+# HEALTHCHECK lets the host-level readiness probe (probe-proxy-readiness.sh)
+# wait for HTTP 200 before marking startup_script/status=COMPLETE.
+HEALTHCHECK --interval=5s --timeout=3s --start-period=60s --retries=3 \
+  CMD curl -sf http://localhost:7080/SASStudio/ || exit 1
+
 # Wrapper entrypoint: copies the SAS license from Mikey Secrets (if active)
 # to /sasinside/ before handing off to the SAS entrypoint.
 COPY --from=wb-secret-receiver /dist/wb-secret-receiver /wb-secret-receiver

--- a/startupscript/butane/probe-proxy-readiness.sh
+++ b/startupscript/butane/probe-proxy-readiness.sh
@@ -11,9 +11,12 @@ set -o xtrace
 # shellcheck source=/dev/null
 source /home/core/metadata-utils.sh
 
+APP_HEALTH="$(docker inspect --format='{{.State.Health.Status}}' application-server 2>/dev/null || echo "none")"
+
 if docker ps -q --filter "name=proxy-agent" | grep -q . \
-    && docker ps -q --filter "name=application-server" | grep -q .; then
-    echo "Proxy is ready."
+    && docker ps -q --filter "name=application-server" | grep -q . \
+    && [[ "${APP_HEALTH}" == "healthy" || "${APP_HEALTH}" == "none" ]]; then
+    echo "Proxy is ready (application-server health: ${APP_HEALTH})."
     status="$(get_guest_attribute "startup_script/status" "")"
     isSuccess="false"
     if [[ "${status}" != "ERROR" ]]; then


### PR DESCRIPTION
## Summary
- Add Docker `HEALTHCHECK` to the SAS Dockerfile that polls `http://localhost:7080/SASStudio/` (5s interval, 60s start period)
- Update `probe-proxy-readiness.sh` to check container health status — requires `healthy` before marking `startup_script/status=COMPLETE`
- Containers without a `HEALTHCHECK` (health status `none`) are unaffected

## Problem
The readiness probe only checks if docker containers are running, but SAS Studio takes ~40s to initialize inside the container. This causes the UI to show "Running" and enable the "Open" button while SAS Studio returns 503.

## Test plan
- [ ] Deploy SAS app in dev and verify UI stays in "Starting" state until SAS Studio is ready
- [ ] Verify non-SAS apps (jupyter, vscode) are unaffected (health status `none` passes through)
- [ ] Verify SAS app transitions to "Running" once healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

PHP-151121