### PR TITLE
Fix readiness probe for containers without HEALTHCHECK

### DIFF
--- a/startupscript/butane/probe-proxy-readiness.sh
+++ b/startupscript/butane/probe-proxy-readiness.sh
@@ -11,7 +11,7 @@ set -o xtrace
 # shellcheck source=/dev/null
 source /home/core/metadata-utils.sh
 
-APP_HEALTH="$(docker inspect --format='{{.State.Health.Status}}' application-server 2>/dev/null || echo "none")"
+APP_HEALTH="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' application-server 2>/dev/null || echo "none")"
 
 if docker ps -q --filter "name=proxy-agent" | grep -q . \
     && docker ps -q --filter "name=application-server" | grep -q . \


### PR DESCRIPTION
## Summary
- Fix `probe-proxy-readiness.sh` to use a Go template conditional (`{{if .State.Health}}`) instead of relying on `docker inspect` exit code to detect containers without a HEALTHCHECK
- This fixes non-SAS apps (jupyter, vscode, etc.) getting stuck in "Starting" state indefinitely

## Problem
PR #415 added health check awareness to the readiness probe, but the Go template `{{.State.Health.Status}}` behaves differently across Docker versions when `.State.Health` is nil (no HEALTHCHECK configured). Some Docker versions return an empty string with exit code 0, bypassing the `|| echo "none"` fallback. This causes `APP_HEALTH=""`, which matches neither `"healthy"` nor `"none"`, so the readiness probe fails forever.

## Fix
```diff
-APP_HEALTH="$(docker inspect --format='{{.State.Health.Status}}' application-server 2>/dev/null || echo "none")"
+APP_HEALTH="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' application-server 2>/dev/null || echo "none")"
```

The Go template conditional handles nil `.State.Health` directly inside the template, making it work reliably regardless of Docker version.

## Test plan
- [ ] Verify non-SAS apps (jupyter, vscode) transition to "Running" state correctly
- [ ] Verify SAS app still waits for healthy status before marking COMPLETE
- [ ] Recreate stuck VMs in vwb-dev-informal-olive-8524 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)