### PR TITLE
Install jupyter-server-proxy in AoU Jupyter image

### DIFF
--- a/src/jupyter-aou/Dockerfile
+++ b/src/jupyter-aou/Dockerfile
@@ -1,5 +1,9 @@
 FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-aou-jupyter@sha256:54504cac626fa9ec61083b87e0c87f2d7859faf7a65830b2e8a743d6a08ac7a2
 
+# Enable /proxy/<PORT> routing so users can access dashboards and other
+# services running inside the container (e.g. Streamlit, Dash, Shiny).
+RUN pip install --no-cache-dir jupyter-server-proxy
+
 # Install jupyter extensions
 RUN --mount=type=bind,from=jupyter-extension-builder,source=/dist,target=/tmp/extensions \
     /tmp/extensions/setup.sh


### PR DESCRIPTION
## Summary
- Installs `jupyter-server-proxy` in the AoU Jupyter Docker image to enable `/proxy/<PORT>` URL routing
- This allows AoU Jupyter users to access dashboards and services (e.g. Streamlit, Dash, Shiny) running inside the container, matching the behavior of non-AoU Jupyter apps
- The existing `server-proxy-notif` extension already checks for this package at runtime and will automatically start working once it's available

## Context
The `/proxy/<PORT>` path works in non-AoU Jupyter apps because their base images include `jupyter-server-proxy`. The AoU base image (`app-aou-jupyter`) does not include it, so requests to `/proxy/<PORT>` fall through to the default JupyterLab handler and the user sees the JupyterLab UI instead of their dashboard.

**Open question:** Was `jupyter-server-proxy` intentionally omitted from AoU for security/compliance reasons, or was it simply not a requirement at the time? Please confirm before merging.

## Test plan
- [ ] Build the AoU Jupyter image and verify `jupyter-server-proxy` is installed (`pip show jupyter-server-proxy`)
- [ ] Start a service on an arbitrary port (e.g. `python -m http.server 8050`) and confirm `/proxy/8050/` routes correctly
- [ ] Verify the `server-proxy-notif` toast notification appears for newly detected ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)