### PR TITLE
Remove AoU workspace bucket environment variable

### DIFF
--- a/src/aou-common/load-envs/internal/envvars/envvars.go
+++ b/src/aou-common/load-envs/internal/envvars/envvars.go
@@ -12,7 +12,6 @@ const (
 	workspaceCDREnvKey = "WORKSPACE_CDR"
 
 	workspaceUfidKey        = "WORKSPACE_UFID"
-	workspaceBucketKey      = "WORKSPACE_BUCKET"
 	cdrStoragePathKey       = "CDR_STORAGE_PATH"
 	artifactRegistryRepoKey = "ARTIFACT_REGISTRY_DOCKER_REPO"
 )
@@ -67,7 +66,6 @@ func GetBaseEnvironmentVariables(
 	customEnvironmentVariables := make(map[string]string)
 
 	customEnvironmentVariables[workspaceUfidKey] = workspaceUfid
-	customEnvironmentVariables[workspaceBucketKey] = fmt.Sprintf("gs://cloned-%s-%s", "mybucket", gcpProject)
 	customEnvironmentVariables[artifactRegistryRepoKey] = accessTier.ArtifactRegistryRepo
 
 	// Add CDR environment variables

--- a/src/aou-common/load-envs/internal/envvars/envvars.go
+++ b/src/aou-common/load-envs/internal/envvars/envvars.go
@@ -1,7 +1,6 @@
 package envvars
 
 import (
-	"fmt"
 	"maps"
 	"reflect"
 	"strings"


### PR DESCRIPTION
The bucket likely does not exist, so we should remove the environment variable. We will add this back in the future when we are able to auto-create buckets in AoU workspaces