### PR TITLE
PHP-160287: Pin nextflow version

### DIFF
--- a/features/src/workbench-tools/install.sh
+++ b/features/src/workbench-tools/install.sh
@@ -88,7 +88,7 @@ readonly CONDA_PACKAGES_BINARIES=(
     "conda-forge::bgenix"
     "conda-forge::cromwell"
     "bioconda::ensembl-vep>=115"
-    "bioconda::nextflow=25.10.02"
+    "bioconda::nextflow=25.10.2"
     "bioconda::plink"
     "bioconda::plink2"
     "bioconda::regenie"

--- a/features/src/workbench-tools/install.sh
+++ b/features/src/workbench-tools/install.sh
@@ -88,7 +88,7 @@ readonly CONDA_PACKAGES_BINARIES=(
     "conda-forge::bgenix"
     "conda-forge::cromwell"
     "bioconda::ensembl-vep>=115"
-    "bioconda::nextflow"
+    "bioconda::nextflow=25.10.02"
     "bioconda::plink"
     "bioconda::plink2"
     "bioconda::regenie"


### PR DESCRIPTION
Nextflow v26 has incompatible config syntax. `wb nextflow` will be deprecated soon, so instead of supporting latest version, use the same nextflow version that workbench uses for workflows created in the UI.

PHP-160287