### PR TITLE
Fix SAS environment variables

### DIFF
--- a/src/aou-sas/sas-pre-deploy.sh
+++ b/src/aou-sas/sas-pre-deploy.sh
@@ -18,11 +18,3 @@ mkdir -p /data/saswork /data/utilloc
 # Chown only the directories we manage, not /data/workspace (contains gcsfuse mounts)
 chown aou:aougroup /data
 chown -R aou:aougroup /data/saswork /data/utilloc
-
-###############################################################################
-# AoU environment loader (staged in Dockerfile at /opt/sas/aou/)
-###############################################################################
-if [ -d /opt/sas/aou ]; then
-  cp -n /opt/sas/aou/load-env /opt/sas/aou/load-env.sh /data/ 2>/dev/null || true
-  chown aou:aougroup /data/load-env /data/load-env.sh 2>/dev/null || true
-fi

--- a/src/aou-sas/setup-sas-env.sh
+++ b/src/aou-sas/setup-sas-env.sh
@@ -14,8 +14,8 @@ set -o pipefail
 readonly USER_NAME="${1}"
 readonly DATA_DIR="${2}"
 
-if [ -f "${DATA_DIR}/load-env.sh" ]; then
-  sudo -u "${USER_NAME}" bash -c "source '${DATA_DIR}/load-env.sh'" || true
+if [ -f "/opt/sas/aou/load-env.sh" ]; then
+  sudo -u "${USER_NAME}" bash -c "source '/opt/sas/aou/load-env.sh'" || true
 fi
 
 # Extract export statements from .bashrc to get workbench environment variables


### PR DESCRIPTION
sas-pre-deploy.sh runs after the postCreate/postStartCommand, so `/data/load-env.sh` wouldn't exist when `setup-sas-env.sh` is run. We should just run the script from `/opt/sas/aou`, where it is created by the Dockerfile.

PHP-160856