### PR TITLE
Configurable /dev/shm using metadata/guest attributes

### DIFF
--- a/src/aou-sas/devcontainer-template.json
+++ b/src/aou-sas/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   }
 }

--- a/src/aou-sas/docker-compose.yaml
+++ b/src/aou-sas/docker-compose.yaml
@@ -4,6 +4,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       additional_contexts:

--- a/src/custom-workbench-jupyter-template/devcontainer-template.json
+++ b/src/custom-workbench-jupyter-template/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/custom-workbench-jupyter-template/docker-compose.yaml
+++ b/src/custom-workbench-jupyter-template/docker-compose.yaml
@@ -3,6 +3,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       additional_contexts:

--- a/src/example/devcontainer-template.json
+++ b/src/example/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   }
 }

--- a/src/example/docker-compose.yaml
+++ b/src/example/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     # The container name must be "application-server"
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     # This can be either a pre-existing image or built from a Dockerfile
     image: "quay.io/jupyter/base-notebook"
     # build:

--- a/src/jupyter-aou/devcontainer-template.json
+++ b/src/jupyter-aou/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/jupyter-aou/docker-compose.yaml
+++ b/src/jupyter-aou/docker-compose.yaml
@@ -4,6 +4,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       additional_contexts:

--- a/src/jupyter-template/devcontainer-template.json
+++ b/src/jupyter-template/devcontainer-template.json
@@ -27,6 +27,11 @@
       "type": "number",
       "description": "The port to expose the container on",
       "default": 8888
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/jupyter-template/docker-compose.yaml
+++ b/src/jupyter-template/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     image: "${templateOption:containerImage}"
     user: "jupyter"
     restart: always

--- a/src/nemo_jupyter/devcontainer-template.json
+++ b/src/nemo_jupyter/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/nemo_jupyter/docker-compose.yaml
+++ b/src/nemo_jupyter/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       target: nemo

--- a/src/nemo_jupyter_aou/devcontainer-template.json
+++ b/src/nemo_jupyter_aou/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/nemo_jupyter_aou/docker-compose.yaml
+++ b/src/nemo_jupyter_aou/docker-compose.yaml
@@ -3,6 +3,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: ../nemo_jupyter
       additional_contexts:

--- a/src/pgweb/devcontainer-template.json
+++ b/src/pgweb/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   }
 }

--- a/src/pgweb/docker-compose.yaml
+++ b/src/pgweb/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     # The container name must be "application-server"
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     # This can be either a pre-existing image or built from a Dockerfile
     build:
       context: .

--- a/src/playground/devcontainer-template.json
+++ b/src/playground/devcontainer-template.json
@@ -2,5 +2,18 @@
   "id": "playground",
   "version": "1.0.0",
   "name": "Playground Apps Manager",
-  "description": "Web-based manager for creating and deploying custom devcontainer applications"
+  "description": "Web-based manager for creating and deploying custom devcontainer applications",
+  "options": {
+    "cloud": {
+      "type": "string",
+      "enum": ["gcp", "aws"],
+      "default": "gcp",
+      "description": "Cloud provider (gcp or aws)"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
+    }
+  }
 }

--- a/src/playground/docker-compose.yaml
+++ b/src/playground/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     # The container name must be "application-server"
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     image: "caddy:2.11-alpine"
     restart: always
     volumes:

--- a/src/r-analysis-aou/devcontainer-template.json
+++ b/src/r-analysis-aou/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/r-analysis-aou/docker-compose.yaml
+++ b/src/r-analysis-aou/docker-compose.yaml
@@ -3,6 +3,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       additional_contexts:

--- a/src/r-analysis/devcontainer-template.json
+++ b/src/r-analysis/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/r-analysis/docker-compose.yaml
+++ b/src/r-analysis/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     image: "ghcr.io/rocker-org/devcontainer/tidyverse@sha256:289c5d02d8115aa209f4a8a49ee9378dccbf623897eed9cc46c87dfbbca9015b"
     restart: always
     volumes:

--- a/src/test-app-secrets/devcontainer-template.json
+++ b/src/test-app-secrets/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   }
 }

--- a/src/test-app-secrets/docker-compose.yaml
+++ b/src/test-app-secrets/docker-compose.yaml
@@ -3,6 +3,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       additional_contexts:

--- a/src/test-app/devcontainer-template.json
+++ b/src/test-app/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   }
 }

--- a/src/test-app/docker-compose.yaml
+++ b/src/test-app/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     # The container name must be "application-server"
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     # This can be either a pre-existing image or built from a Dockerfile
     image: "docker/getting-started"
     # build:

--- a/src/ubuntu-example/devcontainer-template.json
+++ b/src/ubuntu-example/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   }
 }

--- a/src/ubuntu-example/docker-compose.yaml
+++ b/src/ubuntu-example/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     # The container name must be "application-server"
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     # This can be either a pre-existing image or built from a Dockerfile
     image: "mcr.microsoft.com/devcontainers/base:ubuntu-24.04"
     # build:

--- a/src/vscode-docker/devcontainer-template.json
+++ b/src/vscode-docker/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/vscode-docker/docker-compose.yaml
+++ b/src/vscode-docker/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/vscode-with-llm/devcontainer-template.json
+++ b/src/vscode-with-llm/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/vscode-with-llm/docker-compose.yaml
+++ b/src/vscode-with-llm/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/vscode/devcontainer-template.json
+++ b/src/vscode/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/vscode/docker-compose.yaml
+++ b/src/vscode/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/workbench-jupyter-docker/devcontainer-template.json
+++ b/src/workbench-jupyter-docker/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/workbench-jupyter-docker/docker-compose.yaml
+++ b/src/workbench-jupyter-docker/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     image: "us-central1-docker.pkg.dev/verily-workbench-public/apps/workbench-jupyter:latest"
     user: "jupyter:${DOCKER_GID}"
     restart: always

--- a/src/workbench-jupyter-parabricks-aou/devcontainer-template.json
+++ b/src/workbench-jupyter-parabricks-aou/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/workbench-jupyter-parabricks-aou/docker-compose.yaml
+++ b/src/workbench-jupyter-parabricks-aou/docker-compose.yaml
@@ -3,6 +3,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: ../workbench-jupyter-parabricks
       additional_contexts:

--- a/src/workbench-jupyter-parabricks/devcontainer-template.json
+++ b/src/workbench-jupyter-parabricks/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/workbench-jupyter-parabricks/docker-compose.yaml
+++ b/src/workbench-jupyter-parabricks/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       target: parabricks

--- a/src/workbench-jupyter-with-llm/devcontainer-template.json
+++ b/src/workbench-jupyter-with-llm/devcontainer-template.json
@@ -17,6 +17,11 @@
       "description": "Whether to log in to workbench CLI",
       "proposals": ["true", "false"],
       "default": "false"
+    },
+    "shmSize": {
+      "type": "string",
+      "description": "Shared memory size for the application-server container",
+      "default": "64m"
     }
   },
   "platforms": ["Any"]

--- a/src/workbench-jupyter-with-llm/docker-compose.yaml
+++ b/src/workbench-jupyter-with-llm/docker-compose.yaml
@@ -3,6 +3,7 @@ include:
 services:
   app:
     container_name: "application-server"
+    shm_size: "${templateOption:shmSize}"
     build:
       context: .
       additional_contexts:

--- a/startupscript/butane/050-parse-devcontainer.sh
+++ b/startupscript/butane/050-parse-devcontainer.sh
@@ -83,6 +83,14 @@ fi
 /home/core/prefetch-oci-features.sh "${DEVCONTAINER_CONFIG_PATH}" || \
     echo "WARNING: prefetch-oci-features.sh failed, continuing with remote features" >&2
 
+# shellcheck source=/dev/null
+source '/home/core/metadata-utils.sh'
+SHM_SIZE="$(get_metadata_value "shm-size" "")"
+if [[ -z "${SHM_SIZE}" ]]; then
+    SHM_SIZE="$(get_guest_attribute "shm-size" "64m")"
+fi
+readonly SHM_SIZE
+
 replace_template_options() {
     local TEMPLATE_PATH="$1"
 
@@ -91,6 +99,7 @@ replace_template_options() {
     sed -i "s|\${templateOption:cloud}|${CLOUD}|g" "${TEMPLATE_PATH}"
     sed -i "s|\${templateOption:containerImage}|${CONTAINER_IMAGE}|g" "${TEMPLATE_PATH}"
     sed -i "s|\${templateOption:containerPort}|${CONTAINER_PORT}|g" "${TEMPLATE_PATH}"
+    sed -i "s|\${templateOption:shmSize}|${SHM_SIZE}|g" "${TEMPLATE_PATH}"
 }
 
 detect_gpu() {
@@ -169,8 +178,6 @@ else
 fi
 
 echo 'publishing devcontainer.json to metadata'
-# shellcheck source=/dev/null
-source '/home/core/metadata-utils.sh'
 readonly JSONC_STRIP_COMMENTS=/home/core/jsoncStripComments.mjs
 DEVCONTAINER_CUSTOMIZATIONS="$("${JSONC_STRIP_COMMENTS}" < "${DEVCONTAINER_CONFIG_PATH}" | jq -c .customizations.workbench)"
 readonly DEVCONTAINER_CUSTOMIZATIONS

--- a/tests/common/vm-metadata.sh
+++ b/tests/common/vm-metadata.sh
@@ -18,3 +18,12 @@ function get_metadata_value() {
 }
 readonly -f get_metadata_value
 
+function get_guest_attribute() {
+  if [[ -z "$1" ]]; then
+    echo "usage: get_guest_attribute <key>"
+    exit 1
+  fi
+  echo ""
+}
+readonly -f get_guest_attribute
+


### PR DESCRIPTION
Uses metadata if available (for when we have it configurable from the frontend), falls back to guest attributes (which the user can set from inside the VM), then falls back to 64mb if neither are set

To set, curl from within the app:

```shell
curl -X PUT \
  -H "Metadata-Flavor: Google" \
  --data "256m" \
  "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/config/shm-size"
```

PHP-161176