### PR TITLE
Allow trailing b in shm-size unit specification

### DIFF
--- a/startupscript/butane/050-parse-devcontainer.sh
+++ b/startupscript/butane/050-parse-devcontainer.sh
@@ -89,7 +89,7 @@ SHM_SIZE="$(get_metadata_value "shm-size" "")"
 if [[ -z "${SHM_SIZE}" ]]; then
     SHM_SIZE="$(get_guest_attribute "config/shm-size" "")"
 fi
-if [[ ! "${SHM_SIZE}" =~ ^[0-9]+[bBkKmMgG]?$ ]]; then
+if [[ ! "${SHM_SIZE}" =~ ^[0-9]+[bBkKmMgG][bB]?$ ]]; then
     echo "WARNING: invalid shm-size '${SHM_SIZE}', using default 64m" >&2
     SHM_SIZE="64m"
 fi


### PR DESCRIPTION
Allows for "64mb" and not just "64m", following the [docker specification](https://docs.docker.com/reference/compose-file/extension/#specifying-byte-values)