### PR TITLE
Truncate if message exceeds AWS tag size limit

### DIFF
--- a/startupscript/aws/vm-metadata.sh
+++ b/startupscript/aws/vm-metadata.sh
@@ -49,6 +49,16 @@ readonly -f get_metadata_value
 function set_metadata() {
   local key="${1}"
   local value="${2}"
+
+  # AWS tag value limit: 256 characters
+  local max_value_length=256
+
+  # Truncate value if too long
+  if [[ ${#value} -gt ${max_value_length} ]]; then
+    echo "Warning: Tag value for key '${key}' exceeds ${max_value_length} characters, truncating"
+    value="${value:0:${max_value_length}}"
+  fi
+
   # Per the AWS CLI documentation, value is provided within quotes,
   # with " and \ escaped with a \ prefix.
   # https://docs.aws.amazon.com/cli/latest/reference/ec2/create-tags.html

--- a/startupscript/butane/aws/metadata-utils.sh
+++ b/startupscript/butane/aws/metadata-utils.sh
@@ -49,6 +49,16 @@ readonly -f get_guest_attribute
 function set_metadata() {
   local key="${1}"
   local value="${2}"
+
+  # AWS tag value limit: 256 characters
+  local max_value_length=256
+
+  # Truncate value if too long
+  if [[ ${#value} -gt ${max_value_length} ]]; then
+    echo "Warning: Tag value for key '${key}' exceeds ${max_value_length} characters, truncating"
+    value="${value:0:${max_value_length}}"
+  fi
+
   # Per the AWS CLI documentation, value is provided within quotes,
   # with " and \ escaped with a \ prefix.
   # https://docs.aws.amazon.com/cli/latest/reference/ec2/create-tags.html


### PR DESCRIPTION
AWS tag size limit is [very small](https://docs.aws.amazon.com/config/latest/APIReference/API_Tag.html). (GCP guest attributes is much bigger at [256 KB](https://docs.cloud.google.com/compute/docs/metadata/manage-guest-attributes#when_to_use_guest_attributes)) Truncate if message exceeds limit.