### PR TITLE
Remove extra port exposed in workbench-llm app

### DIFF
--- a/src/workbench-jupyter-with-llm/docker-compose.yaml
+++ b/src/workbench-jupyter-with-llm/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
       - .:/workspace:cached
     ports:
       - "8888:8888"
-      - "8080:8080"
     networks:
       - app-network
     cap_add:


### PR DESCRIPTION
This port isn't used and prevents proxy-agent from picking the right port