### PR TITLE
PHP-169182: Transition to using gcloud storage

### DIFF
--- a/features/src/llm-context/generate-context.sh
+++ b/features/src/llm-context/generate-context.sh
@@ -375,7 +375,7 @@ wb resource add-ref aurora-database --name external-db
 
     else
         storage_bucket_type="GCS bucket"
-        storage_save_cmd='gsutil cp <file> gs://<bucket>/'
+        storage_save_cmd='gcloud storage cp <file> gs://<bucket>/'
         resource_table_rows='| `GCS_BUCKET` | Google Cloud Storage bucket | `wb resource create gcs-bucket` |
 | `BQ_DATASET` | BigQuery dataset | `wb resource create bq-dataset` |
 | `GIT_REPO` | Git repository reference | `wb resource add-ref git-repo` |
@@ -386,8 +386,8 @@ wb resource add-ref aurora-database --name external-db
 | `workspace_list_resources` | `wb resource list` | List all resources in the workspace |
 | `resource_list_tree` | `wb resource list-tree` | List resources organized by folder |
 | `bq_execute` | `bq query` | Run SQL queries against BigQuery |
-| `list_files` | `gsutil ls` | List files in a GCS bucket |
-| `read_file` | `gsutil cat` | Read contents of a file |
+| `list_files` | `gcloud storage ls` | List files in a GCS bucket |
+| `read_file` | `gcloud storage cat` | Read contents of a file |
 | `resource_create_bucket` | `wb resource create gcs-bucket` | Create a new GCS bucket |
 | `resource_delete` | `wb resource delete` | Delete a resource |
 | `resource_check_access` | — | Check if service account has access to a resource |
@@ -398,7 +398,6 @@ wb resource add-ref aurora-database --name external-db
 | MCP Tool | Description |
 |----------|-------------|
 | `gcloud_execute` | Run any `gcloud` command |
-| `gsutil_execute` | Run any `gsutil` command |
 | `bq_execute` | Run any `bq` SQL query |'
 
         cloud_path_hint='# Look for: bucketName, projectId+datasetId, gitRepoUrl'
@@ -415,8 +414,8 @@ bq query --use_legacy_sql=false '"'"'SELECT * FROM `project.dataset.table` LIMIT
 
 **GCS:**
 ```bash
-gsutil ls gs://<bucket>/
-gsutil cat -r 0-1024 gs://<bucket>/path/file.csv
+gcloud storage ls gs://<bucket>/
+gcloud storage cat gs://<bucket>/path/file.csv --range=0-1024
 ```
 
 ### Query Data

--- a/features/src/llm-context/skills/WORKFLOW_TROUBLESHOOT.md
+++ b/features/src/llm-context/skills/WORKFLOW_TROUBLESHOOT.md
@@ -105,13 +105,13 @@ echo "stdout: $STDOUT_URL"
 
 ```bash
 # Read stderr (usually contains errors)
-gsutil cat "$STDERR_URL" 2>/dev/null | tail -100
+gcloud storage cat "$STDERR_URL" 2>/dev/null | tail -100
 
 # Read stdout
-gsutil cat "$STDOUT_URL" 2>/dev/null | tail -100
+gcloud storage cat "$STDOUT_URL" 2>/dev/null | tail -100
 
 # Search for common error patterns
-gsutil cat "$STDERR_URL" 2>/dev/null | grep -i -E "error|exception|failed|denied|killed|oom|memory|disk|timeout" | head -30
+gcloud storage cat "$STDERR_URL" 2>/dev/null | grep -i -E "error|exception|failed|denied|killed|oom|memory|disk|timeout" | head -30
 ```
 
 #### Common Log File Patterns
@@ -131,9 +131,9 @@ gs://<execution-bucket>/<workflow-id>/<call-name>/execution/
 # Find execution directory from task describe, then:
 EXEC_DIR=$(echo $TASK_INFO | jq -r '.executionDirectory // empty')
 if [ -n "$EXEC_DIR" ]; then
-  echo "=== script ===" && gsutil cat "$EXEC_DIR/script" 2>/dev/null
-  echo "=== rc ===" && gsutil cat "$EXEC_DIR/rc" 2>/dev/null
-  echo "=== stderr (last 50 lines) ===" && gsutil cat "$EXEC_DIR/stderr" 2>/dev/null | tail -50
+  echo "=== script ===" && gcloud storage cat "$EXEC_DIR/script" 2>/dev/null
+  echo "=== rc ===" && gcloud storage cat "$EXEC_DIR/rc" 2>/dev/null
+  echo "=== stderr (last 50 lines) ===" && gcloud storage cat "$EXEC_DIR/stderr" 2>/dev/null | tail -50
 fi
 ```
 
@@ -148,7 +148,7 @@ fi
 wb workflow describe --workflow=<WORKFLOW_ID> --format=json | jq '.sourceUrl'
 
 # Read WDL file
-gsutil cat gs://<bucket>/<path>/workflow.wdl | grep -A10 "runtime {"
+gcloud storage cat gs://<bucket>/<path>/workflow.wdl | grep -A10 "runtime {"
 ```
 
 #### Check Actual Resource Usage (GCP Batch)
@@ -169,13 +169,13 @@ gcloud batch jobs describe <BATCH_JOB_NAME> --format=json | jq '{
 
 ```bash
 # Check if OOM (Out of Memory) killed the task
-gsutil cat "$STDERR_URL" 2>/dev/null | grep -i -E "oom|out of memory|killed|cannot allocate|memory"
+gcloud storage cat "$STDERR_URL" 2>/dev/null | grep -i -E "oom|out of memory|killed|cannot allocate|memory"
 
 # Check what memory was requested in batch job
 gcloud batch jobs describe <BATCH_JOB_NAME> --format=json | jq '.taskGroups[0].taskSpec.computeResource.memoryMib'
 
 # Check dmesg/syslog for OOM events (if available in logs)
-gsutil cat "$STDERR_URL" 2>/dev/null | grep -i "killed process"
+gcloud storage cat "$STDERR_URL" 2>/dev/null | grep -i "killed process"
 ```
 
 ---
@@ -196,7 +196,7 @@ gsutil cat "$STDERR_URL" 2>/dev/null | grep -i "killed process"
 gcloud batch jobs describe <BATCH_JOB_NAME> --format=json | jq '.taskGroups[0].taskSpec.computeResource'
 
 # Look for memory errors in logs
-gsutil cat "$STDERR_URL" 2>/dev/null | grep -i -E "memory|oom|killed|malloc"
+gcloud storage cat "$STDERR_URL" 2>/dev/null | grep -i -E "memory|oom|killed|malloc"
 ```
 
 **Fix:** Increase `memory` in WDL runtime block:
@@ -214,7 +214,7 @@ runtime {
 
 **Diagnosis:**
 ```bash
-gsutil cat "$STDERR_URL" 2>/dev/null | grep -i -E "space|disk|quota"
+gcloud storage cat "$STDERR_URL" 2>/dev/null | grep -i -E "space|disk|quota"
 ```
 
 **Fix:** Increase disk in WDL runtime:
@@ -236,7 +236,7 @@ runtime {
 # Check if input files exist
 wb workflow job describe --job=<JOB_ID> --format=json | jq -r '.inputs | to_entries[] | .value' | while read path; do
   if [[ $path == gs://* ]]; then
-    echo -n "$path: " && gsutil ls "$path" 2>&1 | head -1
+    echo -n "$path: " && gcloud storage ls "$path" 2>&1 | head -1
   fi
 done
 ```
@@ -254,7 +254,7 @@ done
 gcloud batch jobs describe <BATCH_JOB_NAME> --format=json | jq '.taskGroups[0].taskSpec.serviceAccount'
 
 # Test bucket access
-gsutil ls gs://<bucket>/ 2>&1 | head -5
+gcloud storage ls gs://<bucket>/ 2>&1 | head -5
 ```
 
 ---
@@ -267,7 +267,7 @@ Based on diagnosis, recommend one of:
 |-------|-------------------|
 | **OOM** | "Increase memory from X to Y in the runtime block" |
 | **Disk full** | "Increase disk size from X to Y GB" |
-| **Missing input** | "Input file doesn't exist. Verify path: `gsutil ls <path>`" |
+| **Missing input** | "Input file doesn't exist. Verify path: `gcloud storage ls <path>`" |
 | **Permission** | "Service account lacks access. Grant `roles/storage.objectViewer` on bucket" |
 | **Timeout** | "Task exceeded time limit. Increase `maxRetries` or optimize task" |
 | **Docker** | "Image pull failed. Verify image exists and is accessible" |
@@ -295,7 +295,7 @@ wb workflow job describe --job=<ID> --format=json | jq '.failureMessage'
 wb workflow job task list --job=<ID> --format=json | jq '.[] | select(.status=="FAILED") | .name'
 
 # Task logs
-wb workflow job task describe --job=<ID> --task=<TASK> --format=json | jq '.stderr' | xargs -I{} gsutil cat {} | tail -50
+wb workflow job task describe --job=<ID> --task=<TASK> --format=json | jq '.stderr' | xargs -I{} gcloud storage cat {} | tail -50
 
 # Memory check
 gcloud batch jobs describe <BATCH_JOB> --format=json | jq '.taskGroups[0].taskSpec.computeResource'

--- a/src/aou-common/extension-builder/snippets/python/storage/All_of_Us_Python_and_Cloud_Storage_snippets/2_List_objects_in_Workspace_Bucket/list_objects_in_bucket.py.py
+++ b/src/aou-common/extension-builder/snippets/python/storage/All_of_Us_Python_and_Cloud_Storage_snippets/2_List_objects_in_Workspace_Bucket/list_objects_in_bucket.py.py
@@ -6,6 +6,6 @@
 my_bucket = os.getenv('WORKSPACE_BUCKET')
 
 # List objects in the bucket
-print(subprocess.check_output(f"gsutil ls -r {my_bucket}", shell=True).decode('utf-8'))
+print(subprocess.check_output(f"gcloud storage ls -r {my_bucket}", shell=True).decode('utf-8'))
 
 

--- a/src/aou-common/extension-builder/snippets/python/storage/All_of_Us_Python_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_data_to_workspace_bucket.py.py
+++ b/src/aou-common/extension-builder/snippets/python/storage/All_of_Us_Python_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_data_to_workspace_bucket.py.py
@@ -21,8 +21,8 @@ my_dataframe.to_csv(destination_filename, index=False)
 my_bucket = os.getenv('WORKSPACE_BUCKET')
 
 # copy csv file to the bucket
-args = ["gsutil", "cp", f"./{destination_filename}", f"{my_bucket}/data/"]
+args = ["gcloud", "storage", "cp", f"./{destination_filename}", f"{my_bucket}/data/"]
 output = subprocess.run(args, capture_output=True)
 
-# print output from gsutil
+# print output from gcloud storage
 output.stderr

--- a/src/aou-common/extension-builder/snippets/python/storage/All_of_Us_Python_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_file_from_workspace_bucket.py.py
+++ b/src/aou-common/extension-builder/snippets/python/storage/All_of_Us_Python_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_file_from_workspace_bucket.py.py
@@ -15,7 +15,7 @@ name_of_file_in_bucket = 'test.csv'
 my_bucket = os.getenv('WORKSPACE_BUCKET')
 
 # copy csv file from the bucket to the current working space
-os.system(f"gsutil cp '{my_bucket}/data/{name_of_file_in_bucket}' .")
+os.system(f"gcloud storage cp '{my_bucket}/data/{name_of_file_in_bucket}' .")
 
 print(f'[INFO] {name_of_file_in_bucket} is successfully downloaded into your working space')
 # save dataframe in a csv file in the same workspace as the notebook

--- a/src/aou-common/extension-builder/snippets/r/storage/All_of_Us_R_and_Cloud_Storage_snippets/2_List_objects_in_Workspace_Bucket/list_objects_in_bucket.R.R
+++ b/src/aou-common/extension-builder/snippets/r/storage/All_of_Us_R_and_Cloud_Storage_snippets/2_List_objects_in_Workspace_Bucket/list_objects_in_bucket.R.R
@@ -6,6 +6,6 @@
 my_bucket <- Sys.getenv('WORKSPACE_BUCKET')
 
 # List objects in the bucket
-system(paste0("gsutil ls -r ", my_bucket), intern=T)
+system(paste0("gcloud storage ls -r ", my_bucket), intern=T)
 
 

--- a/src/aou-common/extension-builder/snippets/r/storage/All_of_Us_R_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_data_to_workspace_bucket.R.R
+++ b/src/aou-common/extension-builder/snippets/r/storage/All_of_Us_R_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_data_to_workspace_bucket.R.R
@@ -21,7 +21,7 @@ write_excel_csv(my_dataframe, destination_filename)
 my_bucket <- Sys.getenv('WORKSPACE_BUCKET')
 
 # Copy the file from current workspace to the bucket
-system(paste0("gsutil cp ./", destination_filename, " ", my_bucket, "/data/"), intern=T)
+system(paste0("gcloud storage cp ./", destination_filename, " ", my_bucket, "/data/"), intern=T)
 
 # Check if file is in the bucket
-system(paste0("gsutil ls ", my_bucket, "/data/*.csv"), intern=T)
+system(paste0("gcloud storage ls ", my_bucket, "/data/*.csv"), intern=T)

--- a/src/aou-common/extension-builder/snippets/r/storage/All_of_Us_R_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_file_from_workspace_bucket.R.R
+++ b/src/aou-common/extension-builder/snippets/r/storage/All_of_Us_R_and_Cloud_Storage_snippets/3_Copy_file_to_or_from_Workspace_Bucket/copy_file_from_workspace_bucket.R.R
@@ -15,7 +15,7 @@ name_of_file_in_bucket <- 'test.csv'
 my_bucket <- Sys.getenv('WORKSPACE_BUCKET')
 
 # Copy the file from current workspace to the bucket
-system(paste0("gsutil cp ", my_bucket, "/data/", name_of_file_in_bucket, " ."), intern=T)
+system(paste0("gcloud storage cp ", my_bucket, "/data/", name_of_file_in_bucket, " ."), intern=T)
 
 # Load the file into a dataframe
 my_dataframe  <- read_csv(name_of_file_in_bucket)

--- a/startupscript/dataproc/startup.sh
+++ b/startupscript/dataproc/startup.sh
@@ -25,7 +25,7 @@
 #
 # How to test changes to this file:
 #   Copy this file to a GCS bucket:
-#   - gsutil cp startupscript/dataproc/startup.sh gs://MYBUCKET
+#   - gcloud storage cp startupscript/dataproc/startup.sh gs://MYBUCKET
 #
 #   Create a new VM (JupyterLab provided by Dataproc spark):
 #   - terra resource create dataproc-cluster \
@@ -1218,7 +1218,7 @@ wheel_path = get_metadata('WHEEL')
 wheel_name = wheel_path.split('/')[-1]
 
 print('copying wheel')
-safe_call('gsutil', 'cp', wheel_path, f'/home/hail/{wheel_name}')
+safe_call('gcloud', 'storage', 'cp', wheel_path, f'/home/hail/{wheel_name}')
 
 safe_call('${RUN_PIP}', 'install', '--no-dependencies', f'/home/hail/{wheel_name}')
 


### PR DESCRIPTION
Starting March 2027, Google Cloud will no longer include the gsutil command-line tool in the default Google Cloud CLI installation package. They strongly encourage all users to transition to gcloud storage. See notice mentioned in [this gsutil doc](https://docs.cloud.google.com/storage/docs/gsutil_install).

All our scripts should update to use gcloud storage instead of gsutil. Verified that `gcloud storage` ls, cat, cp all exist, see [here](https://docs.cloud.google.com/sdk/gcloud/reference/storage).

[Explanation of differences ](https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud) between these two commands.