### PR TITLE
Fix aou environment variables for R

### DIFF
--- a/src/r-analysis-aou/.devcontainer.json
+++ b/src/r-analysis-aou/.devcontainer.json
@@ -5,21 +5,9 @@
   "runServices": ["app", "wondershaper"],
   "shutdownAction": "none",
   "workspaceFolder": "/workspace",
-  "postCreateCommand": [
-    "./startupscript/post-startup.sh",
-    "rstudio",
-    "/home/rstudio",
-    "${templateOption:cloud}",
-    "${templateOption:login}"
-  ],
+  "postCreateCommand": "./startupscript/post-startup.sh rstudio /home/rstudio '${templateOption:cloud}' '${templateOption:login}' && ./setup-rstudio-env.sh rstudio",
   // re-mount bucket files on container start up
-  "postStartCommand": [
-    "./startupscript/remount-on-restart.sh",
-    "rstudio",
-    "/home/rstudio",
-    "${templateOption:cloud}",
-    "${templateOption:login}"
-  ],
+  "postStartCommand": "./startupscript/remount-on-restart.sh rstudio /home/rstudio '${templateOption:cloud}' '${templateOption:login}' && ./setup-rstudio-env.sh rstudio",
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a": {
       "version": "17"

--- a/src/r-analysis-aou/Dockerfile
+++ b/src/r-analysis-aou/Dockerfile
@@ -14,12 +14,4 @@ COPY --from=load-envs --chown=$USER \
 
 RUN echo "source $HOME/load-env.sh" >> $HOME/.bashrc
 
-# Source AoU env vars in R sessions via rsession-profile, which RStudio Server
-# reads before starting each R session. Without this, variables exported in
-# .bashrc are visible in the terminal but not via Sys.getenv() in R, because
-# R sessions inherit from the RStudio server process rather than the shell.
-RUN mkdir -p /etc/rstudio && \
-    printf 'if [ -f "${HOME}/load-env.sh" ]; then\n    source "${HOME}/load-env.sh"\nfi\n' \
-    > /etc/rstudio/rsession-profile
-
 # TODO(PHP-87353): Add remotefuse back. See https://github.com/verily-src/workbench-app-devcontainers/pull/227

--- a/src/r-analysis-aou/Dockerfile
+++ b/src/r-analysis-aou/Dockerfile
@@ -14,4 +14,12 @@ COPY --from=load-envs --chown=$USER \
 
 RUN echo "source $HOME/load-env.sh" >> $HOME/.bashrc
 
+# Source AoU env vars in R sessions via rsession-profile, which RStudio Server
+# reads before starting each R session. Without this, variables exported in
+# .bashrc are visible in the terminal but not via Sys.getenv() in R, because
+# R sessions inherit from the RStudio server process rather than the shell.
+RUN mkdir -p /etc/rstudio && \
+    printf 'if [ -f "${HOME}/load-env.sh" ]; then\n    source "${HOME}/load-env.sh"\nfi\n' \
+    > /etc/rstudio/rsession-profile
+
 # TODO(PHP-87353): Add remotefuse back. See https://github.com/verily-src/workbench-app-devcontainers/pull/227

--- a/src/r-analysis-aou/setup-rstudio-env.sh
+++ b/src/r-analysis-aou/setup-rstudio-env.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
-# setup-rstudio-env.sh — Populate ~/.aou-env for R sessions.
+# setup-rstudio-env.sh — Populate AoU environment variables for R sessions.
 #
-# Runs after post-startup.sh (or remount-on-restart.sh) to pre-warm the
-# load-env cache so that rsession-profile can source it without blocking
-# R session startup on an API call.
+# Runs after post-startup.sh (or remount-on-restart.sh) to write AoU variables
+# into Renviron.site so that R sessions can access them via Sys.getenv().
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
 readonly USER_NAME="${1}"
+readonly RENVIRON_SITE="/usr/local/lib/R/etc/Renviron.site"
+
 sudo -u "${USER_NAME}" bash -c 'source "$HOME/load-env.sh"' || true
+
+HOME_DIR="$(getent passwd "${USER_NAME}" | cut -d: -f6)"
+if [ -f "${HOME_DIR}/.aou-env" ]; then
+  sed -i '/### BEGIN: AoU ###/,/### END: AoU ###/d' "${RENVIRON_SITE}"
+  {
+    echo "### BEGIN: AoU ###"
+    sed 's/^export //' "${HOME_DIR}/.aou-env"
+    echo "### END: AoU ###"
+  } >> "${RENVIRON_SITE}"
+fi

--- a/src/r-analysis-aou/setup-rstudio-env.sh
+++ b/src/r-analysis-aou/setup-rstudio-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# setup-rstudio-env.sh — Populate ~/.aou-env for R sessions.
+#
+# Runs after post-startup.sh (or remount-on-restart.sh) to pre-warm the
+# load-env cache so that rsession-profile can source it without blocking
+# R session startup on an API call.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly USER_NAME="${1}"
+sudo -u "${USER_NAME}" bash -c 'source "$HOME/load-env.sh"' || true


### PR DESCRIPTION
The user's R environment has its own environment variables, separate from the user's environment variables. Load environment variables into the R environment by copying them to Renviron.site

PHP-171347