### PR TITLE
fix(idle-shutdown): base CPU activity on the application container rather than whole-VM load

### DIFF
--- a/.github/workflows/test-scripts.yaml
+++ b/.github/workflows/test-scripts.yaml
@@ -3,12 +3,16 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      - 'startupscript/butane/**'
+      - 'tests/*.bats'
       - '.github/workflows/test-scripts.yaml'
   push:
     branches:
       - master
     paths:
       - 'scripts/**'
+      - 'startupscript/butane/**'
+      - 'tests/*.bats'
       - '.github/workflows/test-scripts.yaml'
 
 jobs:
@@ -27,3 +31,17 @@ jobs:
         run: |
           cd scripts/test
           bats create-custom-app.bats
+
+  test-probe-user-access:
+    name: "Test probe-user-access.sh"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats-core
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - name: Run bats tests
+        run: bats tests/test-probe-user-access.bats

--- a/startupscript/butane/probe-user-access.sh
+++ b/startupscript/butane/probe-user-access.sh
@@ -1,27 +1,103 @@
 #!/bin/bash
 
-# probe-user-access.sh checks for the latest user activity on the VM based on
-# cpu load and last forwarded request to the backend.
+# probe-user-access.sh records the latest user activity on the VM as guest
+# attributes, which idle-shutdown.sh reads to decide whether to stop the VM.
 #
-# usage: probe-user-access.sh <threshold>. 
-# If threshold is specified, it will be used to determine cpu idlenss. When cpu 
-# average usage is lower than the threshold, we determine the machine is idle.
-# The default threshold is 0.1 (10 percent).
+# Three independent signals are recorded, and idle-shutdown.sh takes the most
+# recent of the three:
+#   last-active/proxy - last request forwarded to the backend by the proxy agent
+#   last-active/ssh   - an interactive ssh session is present
+#   last-active/cpu   - CPU activity of the application container (see below)
+#
+# CPU ACTIVITY IS MEASURED PER CONTAINER, NOT PER VM.
+# This script used to derive CPU activity from the whole-VM 15-minute load
+# average (/proc/loadavg). That attributes CPU burned by sidecar containers to
+# the user: any template that runs a continuously busy sidecar keeps the load
+# average above the threshold forever, so last-active/cpu is refreshed on every
+# probe, idle-shutdown.sh never fires, and the VM bills indefinitely even though
+# nobody is using it. We therefore measure only the container that runs the
+# user's workload.
+#
+# UNITS: the container CPU threshold is a percentage of ONE CPU core, computed
+# from the container's cgroup CPU accounting. 100.0 means the container consumed
+# one core continuously across the sample interval; the value can exceed 100.0
+# on a multi-vCPU VM (a 4-vCPU VM tops out at 400.0). It is deliberately NOT
+# normalized by core count, so the threshold means the same thing on every
+# machine size. This is a different unit and a different scale from
+# /proc/loadavg, so the default threshold is not the same number the
+# load-average check used -- see DEFAULT_CPU_PERCENT_THRESHOLD below.
+#
+# usage: probe-user-access.sh [load-threshold] [container-cpu-percent-threshold]
+#   $1 load-threshold (default 0.1). Unchanged meaning: a whole-VM 15-minute
+#      load average. Now only consulted by the fallback path described below.
+#   $2 container-cpu-percent-threshold (default 5.0), as a percentage of one
+#      core. Below this the application container is considered idle.
+#
+# The container to measure defaults to "application-server" and can be
+# overridden per VM with the "idle-cpu-container-name" instance attribute,
+# for templates where the user's workload runs in a differently named container.
+#
+# If the container cannot be measured at all -- it does not exist yet, is not
+# running, or exposes no cgroup CPU accounting -- the script falls back to the
+# previous whole-VM load-average behaviour using $1. Falling back keeps the VM
+# alive rather than risking a premature shutdown of a workspace we cannot
+# measure.
 
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-# shellcheck source=/dev/null
-source /home/core/metadata-utils.sh
+# Logs to stderr, not stdout: the helpers below return their values on stdout
+# via command substitution, so log lines must not be captured with them.
+function emit() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >&2
+}
+readonly -f emit
 
-THRESHOLD="${1:-0.1}"
-readonly CONTAINER_NAME="proxy-agent"
-if [[ "$(docker container inspect -f '{{.State.Running}}' "${CONTAINER_NAME}")" == "true" ]]; then
+# Allow tests to point at a stub. Production always uses /home/core.
+METADATA_UTILS="${METADATA_UTILS:-/home/core/metadata-utils.sh}"
+readonly METADATA_UTILS
+# shellcheck source=/dev/null
+source "${METADATA_UTILS}"
+
+readonly DEFAULT_LOAD_THRESHOLD="0.1"
+# 5% of one core. An idle application server (ioloop heartbeats, autosave,
+# health checks) sits well under 2% of a core, while genuine user work is
+# far above 5%. For reference the old load-average threshold of 0.1 meant
+# "one runnable task 10% of the time", i.e. roughly 10% of one core measured
+# across the whole VM; now that sidecar and host noise is excluded we can
+# afford to be more sensitive than that.
+readonly DEFAULT_CPU_PERCENT_THRESHOLD="5.0"
+readonly DEFAULT_APP_CONTAINER_NAME="application-server"
+readonly APP_CONTAINER_METADATA_KEY="idle-cpu-container-name"
+
+# CGROUP_ROOT, PROC_ROOT and STATE_DIR are overridable only so the unit tests
+# can point at fixtures. Production always uses the real paths.
+readonly CGROUP_ROOT="${CGROUP_ROOT:-/sys/fs/cgroup}"
+readonly PROC_ROOT="${PROC_ROOT:-/proc}"
+readonly STATE_DIR="${STATE_DIR:-/run/probe-user-access}"
+readonly STATE_FILE="${STATE_DIR}/app-cpu-sample"
+# Only used when there is no previous sample to diff against.
+readonly FALLBACK_SAMPLE_SECONDS="${FALLBACK_SAMPLE_SECONDS:-3}"
+# A gap shorter than this is too small to average over, so the previous
+# sample is discarded and an in-place sample is taken instead.
+readonly MIN_SAMPLE_NSEC=1000000000
+
+LOAD_THRESHOLD="${1:-${DEFAULT_LOAD_THRESHOLD}}"
+readonly LOAD_THRESHOLD
+CPU_PERCENT_THRESHOLD="${2:-${DEFAULT_CPU_PERCENT_THRESHOLD}}"
+readonly CPU_PERCENT_THRESHOLD
+
+###############################################################################
+# Proxy activity (unchanged)
+###############################################################################
+
+readonly PROXY_CONTAINER_NAME="proxy-agent"
+if [[ "$(docker container inspect -f '{{.State.Running}}' "${PROXY_CONTAINER_NAME}")" == "true" ]]; then
     # Tolerates pipefail here when there's no matching log.
     # example logs: 2024/03/29 16:15:58 Forwarded request to backend
-    LOG="$(docker logs "${CONTAINER_NAME}" 2>&1 | grep 'Forwarded request to backend' | tail -1 || true)"
+    LOG="$(docker logs "${PROXY_CONTAINER_NAME}" 2>&1 | grep 'Forwarded request to backend' | tail -1 || true)"
     if [[ -n "${LOG}" ]]; then
         TIMESTAMP=$(echo "${LOG}" | awk '{print $1 " " $2}')
         UNIX_TIME=$(date -d "${TIMESTAMP}" +"%s")
@@ -29,16 +105,176 @@ if [[ "$(docker container inspect -f '{{.State.Running}}' "${CONTAINER_NAME}")" 
     fi
 fi
 
-LOAD="$(awk '{print $3}' /proc/loadavg)" # 15-minute average load
-echo "CPU load is ${LOAD}"
-# Check if the LOAD has exceeded the THRESHOLD.  
-# Note the use of awk for comparison of real numbers.  
-if echo "${THRESHOLD}" "${LOAD}" | awk '{if ($1 > $2) exit 0; else exit 1}'; then
-    echo "Idling.."
-else
-    NOW="$(date +'%s')"
-    set_metadata "last-active/cpu" "${NOW}"
+###############################################################################
+# Application container CPU activity
+###############################################################################
+
+# Echoes "<file> <unit>" for the cgroup CPU accounting of the given pid, where
+# unit is "usec" (cgroup v2 cpu.stat) or "nsec" (cgroup v1 cpuacct.usage).
+# Returns non-zero if no readable accounting file was found.
+function find_cpu_acct_file() {
+  local pid="$1"
+  local proc_cgroup="${PROC_ROOT}/${pid}/cgroup"
+  if [[ ! -r "${proc_cgroup}" ]]; then
+    return 1
+  fi
+
+  local rel
+  # cgroup v2 lists a single unified hierarchy as "0::<path>".
+  rel="$(awk -F: '$1 == "0" && $2 == "" {print $3; exit}' "${proc_cgroup}")"
+  if [[ -n "${rel}" && -r "${CGROUP_ROOT}${rel}/cpu.stat" ]]; then
+    echo "${CGROUP_ROOT}${rel}/cpu.stat usec"
+    return 0
+  fi
+
+  # cgroup v1 keeps a cumulative nanosecond counter under the cpuacct
+  # controller, which may be mounted alone or co-mounted as "cpu,cpuacct".
+  rel="$(awk -F: '$2 ~ /(^|,)cpuacct(,|$)/ {print $3; exit}' "${proc_cgroup}")"
+  if [[ -n "${rel}" && -r "${CGROUP_ROOT}/cpuacct${rel}/cpuacct.usage" ]]; then
+    echo "${CGROUP_ROOT}/cpuacct${rel}/cpuacct.usage nsec"
+    return 0
+  fi
+
+  return 1
+}
+readonly -f find_cpu_acct_file
+
+# Echoes the cumulative CPU time of the accounting file in microseconds.
+function read_cpu_usage_usec() {
+  local file="$1"
+  local unit="$2"
+  local raw
+
+  if [[ "${unit}" == "usec" ]]; then
+    raw="$(awk '$1 == "usage_usec" {print $2; found = 1} END {exit !found}' "${file}")" || return 1
+  else
+    raw="$(cat "${file}")" || return 1
+  fi
+
+  if [[ ! "${raw}" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  if [[ "${unit}" == "usec" ]]; then
+    echo "${raw}"
+  else
+    echo "$(( raw / 1000 ))"
+  fi
+}
+readonly -f read_cpu_usage_usec
+
+# Echoes "<cpu_usec> <monotonic_nsec>" for the given pid.
+function sample_cpu() {
+  local file="$1"
+  local unit="$2"
+  local usage
+  usage="$(read_cpu_usage_usec "${file}" "${unit}")" || return 1
+  echo "${usage} $(date +%s%N)"
+}
+readonly -f sample_cpu
+
+# Echoes the CPU usage of the named container as a percentage of one core.
+# Returns non-zero if the container cannot be measured.
+function measure_container_cpu_percent() {
+  local container="$1"
+
+  local inspected
+  inspected="$(docker inspect --format '{{.Id}} {{.State.Pid}}' "${container}" 2>/dev/null)" || return 1
+  local id pid
+  read -r id pid <<<"${inspected}"
+  # A stopped or never-started container reports pid 0.
+  if [[ ! "${pid}" =~ ^[0-9]+$ ]] || (( pid == 0 )); then
+    return 1
+  fi
+
+  local acct file unit
+  acct="$(find_cpu_acct_file "${pid}")" || return 1
+  read -r file unit <<<"${acct}"
+
+  local usage_now stamp_now sample
+  sample="$(sample_cpu "${file}" "${unit}")" || return 1
+  read -r usage_now stamp_now <<<"${sample}"
+
+  # Prefer diffing against the sample taken by the previous probe run: it
+  # averages CPU over the whole inter-probe interval, which smooths out short
+  # bursts, and it costs nothing. /run is a tmpfs so the state never survives a
+  # reboot, and a container restart is caught by comparing the container id.
+  local usage_before stamp_before prev_id prev_usage prev_stamp
+  usage_before=""
+  stamp_before=""
+  if read -r prev_id prev_usage prev_stamp < "${STATE_FILE}" 2>/dev/null \
+      && [[ "${prev_id}" == "${id}" ]] \
+      && [[ "${prev_usage}" =~ ^[0-9]+$ && "${prev_stamp}" =~ ^[0-9]+$ ]] \
+      && (( usage_now >= prev_usage )) \
+      && (( stamp_now - prev_stamp >= MIN_SAMPLE_NSEC )); then
+    usage_before="${prev_usage}"
+    stamp_before="${prev_stamp}"
+  fi
+
+  if [[ -z "${usage_before}" ]]; then
+    # First probe after boot, or the container just restarted, so there is no
+    # usable baseline. Take a short sample in place rather than guessing.
+    emit "No usable previous CPU sample for ${container}; sampling for ${FALLBACK_SAMPLE_SECONDS}s."
+    usage_before="${usage_now}"
+    stamp_before="${stamp_now}"
+    sleep "${FALLBACK_SAMPLE_SECONDS}"
+    sample="$(sample_cpu "${file}" "${unit}")" || return 1
+    read -r usage_now stamp_now <<<"${sample}"
+    if (( usage_now < usage_before || stamp_now <= stamp_before )); then
+      return 1
+    fi
+  fi
+
+  mkdir -p "${STATE_DIR}"
+  echo "${id} ${usage_now} ${stamp_now}" > "${STATE_FILE}"
+
+  # Percent of one core, i.e. cpu time used / wall time elapsed * 100. The
+  # elapsed time is in nanoseconds and the used time in microseconds, so the
+  # 1000x unit difference folds into the multiplier: 100 * 1000 = 100000.
+  awk -v used="$(( usage_now - usage_before ))" \
+      -v elapsed_nsec="$(( stamp_now - stamp_before ))" \
+      'BEGIN { printf "%.2f", (used * 100000) / elapsed_nsec }'
+}
+readonly -f measure_container_cpu_percent
+
+APP_CONTAINER_NAME="$(get_metadata_value "${APP_CONTAINER_METADATA_KEY}" "${DEFAULT_APP_CONTAINER_NAME}")"
+if [[ -z "${APP_CONTAINER_NAME}" ]]; then
+  APP_CONTAINER_NAME="${DEFAULT_APP_CONTAINER_NAME}"
 fi
+readonly APP_CONTAINER_NAME
+
+CPU_IS_ACTIVE="false"
+CPU_PERCENT="$(measure_container_cpu_percent "${APP_CONTAINER_NAME}" || true)"
+readonly CPU_PERCENT
+if [[ -n "${CPU_PERCENT}" ]]; then
+  emit "Container ${APP_CONTAINER_NAME} CPU usage is ${CPU_PERCENT}% of one core (threshold ${CPU_PERCENT_THRESHOLD}%)."
+  # Note the use of awk for comparison of real numbers.
+  if echo "${CPU_PERCENT_THRESHOLD}" "${CPU_PERCENT}" | awk '{if ($1 > $2) exit 0; else exit 1}'; then
+    emit "Container ${APP_CONTAINER_NAME} is idle."
+  else
+    CPU_IS_ACTIVE="true"
+  fi
+else
+  # Could not measure the container. Fall back to the previous whole-VM
+  # load-average behaviour so an unmeasurable container cannot cause a
+  # premature shutdown.
+  LOAD="$(awk '{print $3}' "${PROC_ROOT}/loadavg")" # 15-minute average load
+  emit "Could not measure CPU for container ${APP_CONTAINER_NAME}; falling back to whole-VM load average ${LOAD} (threshold ${LOAD_THRESHOLD})."
+  if echo "${LOAD_THRESHOLD}" "${LOAD}" | awk '{if ($1 > $2) exit 0; else exit 1}'; then
+    emit "Idling.."
+  else
+    CPU_IS_ACTIVE="true"
+  fi
+fi
+readonly CPU_IS_ACTIVE
+
+if [[ "${CPU_IS_ACTIVE}" == "true" ]]; then
+  NOW="$(date +'%s')"
+  set_metadata "last-active/cpu" "${NOW}"
+fi
+
+###############################################################################
+# SSH activity (unchanged)
+###############################################################################
 
 if pgrep -af 'sshd-session.*@'; then
   echo "Detect an active ssh session"

--- a/tests/test-probe-user-access.bats
+++ b/tests/test-probe-user-access.bats
@@ -1,0 +1,403 @@
+#!/usr/bin/env bats
+# Unit tests for startupscript/butane/probe-user-access.sh.
+#
+# The script is driven end to end against fixtures: a stub PATH (docker, date,
+# sleep, pgrep), a stub metadata-utils.sh, a fake /proc tree and a fake cgroup
+# tree. The stubbed clock makes the sampling arithmetic exact, so the tests can
+# assert precise CPU percentages and threshold boundaries.
+
+setup_file() {
+    echo "# Running ${BATS_TEST_FILENAME##*/}" >&3
+}
+
+setup() {
+    DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" >/dev/null 2>&1 && pwd)"
+    REPO_ROOT="$(cd "${DIR}/.." && pwd)"
+    SCRIPT="${REPO_ROOT}/startupscript/butane/probe-user-access.sh"
+
+    # BATS_TEST_TMPDIR needs bats >= 1.4; fall back for older packages.
+    TMP="${BATS_TEST_TMPDIR:-$(mktemp -d)}"
+    STUB_BIN="${TMP}/bin"
+    PROC="${TMP}/proc"
+    CGROUP="${TMP}/cgroup"
+    STATE="${TMP}/state"
+    METADATA_LOG="${TMP}/metadata.log"
+    CLOCK_QUEUE="${TMP}/clock"
+    mkdir -p "${STUB_BIN}" "${PROC}" "${CGROUP}" "${STATE}"
+    : > "${METADATA_LOG}"
+    : > "${CLOCK_QUEUE}"
+
+    # An idle VM load average, so any fallback to /proc/loadavg reads as idle
+    # unless a test overrides it.
+    echo "0.00 0.01 0.02 1/234 5678" > "${PROC}/loadavg"
+
+    # ---- stub: docker -------------------------------------------------------
+    # Only knows about one container, named by STUB_TARGET_CONTAINER. Anything
+    # else is reported as unknown, exactly like a missing container.
+    cat > "${STUB_BIN}/docker" <<'EOF'
+#!/bin/bash
+if [[ "$*" == "container inspect -f {{.State.Running}} proxy-agent" ]]; then
+    echo "${STUB_PROXY_RUNNING:-false}"
+    exit 0
+fi
+if [[ "$1" == "inspect" && "$2" == "--format" ]]; then
+    requested="${!#}"
+    if [[ "${requested}" == "${STUB_TARGET_CONTAINER:-}" ]]; then
+        echo "${STUB_TARGET_INSPECT}"
+        exit 0
+    fi
+    echo "Error: No such object: ${requested}" >&2
+    exit 1
+fi
+exit 1
+EOF
+
+    # ---- stub: date ---------------------------------------------------------
+    # `date +%s%N` pops the next value off a queue so elapsed time is exact.
+    # Every other invocation falls through to the real date.
+    cat > "${STUB_BIN}/date" <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "+%s%N" ]]; then
+    if [[ -s "${STUB_CLOCK_QUEUE}" ]]; then
+        head -n 1 "${STUB_CLOCK_QUEUE}"
+        tail -n +2 "${STUB_CLOCK_QUEUE}" > "${STUB_CLOCK_QUEUE}.next"
+        mv "${STUB_CLOCK_QUEUE}.next" "${STUB_CLOCK_QUEUE}"
+    else
+        echo 0
+    fi
+    exit 0
+fi
+for candidate in /bin/date /usr/bin/date; do
+    [[ -x "${candidate}" ]] && exec "${candidate}" "$@"
+done
+echo "no real date found" >&2
+exit 1
+EOF
+
+    # ---- stub: sleep --------------------------------------------------------
+    # Instant, but runs STUB_SLEEP_HOOK so a test can advance the fake
+    # container's CPU counter "while" the script is sampling.
+    cat > "${STUB_BIN}/sleep" <<'EOF'
+#!/bin/bash
+if [[ -n "${STUB_SLEEP_HOOK:-}" ]]; then
+    eval "${STUB_SLEEP_HOOK}"
+fi
+exit 0
+EOF
+
+    # ---- stub: pgrep --------------------------------------------------------
+    cat > "${STUB_BIN}/pgrep" <<'EOF'
+#!/bin/bash
+[[ "${STUB_SSH_ACTIVE:-false}" == "true" ]] || exit 1
+echo "12345 sshd-session: user@pts/0"
+EOF
+
+    chmod +x "${STUB_BIN}"/*
+
+    # ---- stub: metadata-utils.sh -------------------------------------------
+    cat > "${TMP}/metadata-utils.sh" <<'EOF'
+#!/bin/bash
+function get_metadata_value() {
+    if [[ "$1" == "idle-cpu-container-name" && -n "${STUB_CONTAINER_NAME_METADATA:-}" ]]; then
+        echo "${STUB_CONTAINER_NAME_METADATA}"
+    else
+        echo "$2"
+    fi
+}
+function get_guest_attribute() { echo "$2"; }
+function set_metadata() { echo "$1 $2" >> "${STUB_METADATA_LOG}"; }
+EOF
+
+    export STUB_METADATA_LOG="${METADATA_LOG}"
+    export STUB_CLOCK_QUEUE="${CLOCK_QUEUE}"
+    export METADATA_UTILS="${TMP}/metadata-utils.sh"
+    export CGROUP_ROOT="${CGROUP}"
+    export PROC_ROOT="${PROC}"
+    export STATE_DIR="${STATE}"
+    export PATH="${STUB_BIN}:${PATH}"
+
+    # Timestamps in nanoseconds: a 60 second gap between probe runs.
+    BEFORE_NSEC=1000000000000
+    NOW_NSEC=1060000000000
+    # Over 60s, 1% of one core is 600000 microseconds of CPU time.
+    USEC_PER_PERCENT=600000
+    BASE_USEC=10000000
+    CONTAINER_ID="abc123def456"
+}
+
+# Creates the fake /proc and cgroup v2 entries for a running container.
+# usage: given_cgroup_v2 <pid> <container_id> <usage_usec>
+given_cgroup_v2() {
+    local pid="$1" id="$2" usage="$3"
+    mkdir -p "${PROC}/${pid}"
+    echo "0::/system.slice/docker-${id}.scope" > "${PROC}/${pid}/cgroup"
+    CPU_STAT_FILE="${CGROUP}/system.slice/docker-${id}.scope/cpu.stat"
+    mkdir -p "$(dirname "${CPU_STAT_FILE}")"
+    printf 'usage_usec %s\nuser_usec 1\nsystem_usec 1\n' "${usage}" > "${CPU_STAT_FILE}"
+    export STUB_TARGET_INSPECT="${id} ${pid}"
+}
+
+# usage: given_cgroup_v1 <pid> <container_id> <usage_usec>
+given_cgroup_v1() {
+    local pid="$1" id="$2" usage="$3"
+    mkdir -p "${PROC}/${pid}"
+    echo "4:cpu,cpuacct:/docker/${id}" > "${PROC}/${pid}/cgroup"
+    local file="${CGROUP}/cpuacct/docker/${id}/cpuacct.usage"
+    mkdir -p "$(dirname "${file}")"
+    # cgroup v1 counts nanoseconds.
+    echo "$(( usage * 1000 ))" > "${file}"
+    export STUB_TARGET_INSPECT="${id} ${pid}"
+}
+
+# Seeds the previous probe's sample so the script diffs against it.
+# usage: given_previous_sample <container_id> <usage_usec>
+given_previous_sample() {
+    echo "$1 $2 ${BEFORE_NSEC}" > "${STATE}/app-cpu-sample"
+    echo "${NOW_NSEC}" > "${CLOCK_QUEUE}"
+}
+
+assert_metadata() {
+    grep -q "^$1 " "${METADATA_LOG}"
+}
+
+# Negative assertions must be wrapped in a function: in a bats test body a bare
+# `!` is exempt from errexit unless it is the very last command, so `! foo`
+# would silently pass mid-test.
+refute_metadata() {
+    ! grep -q "^$1 " "${METADATA_LOG}"
+}
+
+###############################################################################
+
+@test "container CPU below threshold does not count as activity" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # 2% of one core.
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 2 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CPU usage is 2.00% of one core"* ]]
+    refute_metadata 'last-active/cpu'
+}
+
+@test "container CPU above threshold counts as activity" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # 100% of one core.
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 100 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CPU usage is 100.00% of one core"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "CPU exactly at the threshold counts as activity" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # Exactly 5.00%, the default threshold. Idle requires strictly less.
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 5 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CPU usage is 5.00% of one core"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "CPU just below the threshold is idle" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 4 * USEC_PER_PERCENT + 100 ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    refute_metadata 'last-active/cpu'
+}
+
+@test "usage above one core is reported and counts as activity" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # 250% of one core: a multi-vCPU workload. Not normalized by core count.
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 250 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [[ "$output" == *"CPU usage is 250.00% of one core"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "explicit container CPU threshold argument is honoured" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # 20% of one core: active at the default 5%, idle at a 50% threshold.
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 20 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}" 0.1 50
+    [ "$status" -eq 0 ]
+    refute_metadata 'last-active/cpu'
+}
+
+@test "cgroup v1 cpuacct accounting is supported" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v1 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 30 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CPU usage is 30.00% of one core"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "the measured container can be overridden by instance metadata" {
+    # application-server exists but is not the workload container; the workload
+    # runs in "jupyterlab", which is what metadata points at.
+    export STUB_TARGET_CONTAINER="jupyterlab"
+    export STUB_CONTAINER_NAME_METADATA="jupyterlab"
+    given_cgroup_v2 777 "${CONTAINER_ID}" "$(( BASE_USEC + 80 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Container jupyterlab CPU usage is 80.00%"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "without the override the default container name is measured" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 80 * USEC_PER_PERCENT ))"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [[ "$output" == *"Container application-server CPU usage is"* ]]
+}
+
+@test "missing container falls back to whole-VM load average" {
+    # No container at all: docker reports no such object.
+    export STUB_TARGET_CONTAINER="nothing-here"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"falling back to whole-VM load average"* ]]
+    # The fixture load average (0.02) is under the 0.1 fallback threshold.
+    refute_metadata 'last-active/cpu'
+}
+
+@test "fallback load average above the threshold counts as activity" {
+    export STUB_TARGET_CONTAINER="nothing-here"
+    echo "1.50 1.40 1.30 1/234 5678" > "${PROC}/loadavg"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"falling back to whole-VM load average"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "the load-average argument still controls the fallback threshold" {
+    export STUB_TARGET_CONTAINER="nothing-here"
+    echo "0.50 0.50 0.50 1/234 5678" > "${PROC}/loadavg"
+
+    # Active at the default 0.1, idle at a 2.0 load threshold.
+    run bash "${SCRIPT}" 2.0
+    [ "$status" -eq 0 ]
+    refute_metadata 'last-active/cpu'
+}
+
+@test "stopped container falls back to whole-VM load average" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # A stopped container reports pid 0.
+    export STUB_TARGET_INSPECT="${CONTAINER_ID} 0"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"falling back to whole-VM load average"* ]]
+}
+
+@test "missing cgroup accounting falls back to whole-VM load average" {
+    export STUB_TARGET_CONTAINER="application-server"
+    # A live pid whose cgroup file does not exist.
+    export STUB_TARGET_INSPECT="${CONTAINER_ID} 9999"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"falling back to whole-VM load average"* ]]
+}
+
+@test "no previous sample takes a short in-place sample" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "${BASE_USEC}"
+    # No state file. The clock supplies both ends of the in-place sample: a
+    # 3 second window, during which the counter advances by 3s of CPU time.
+    printf '%s\n%s\n' "${BEFORE_NSEC}" "$(( BEFORE_NSEC + 3000000000 ))" > "${CLOCK_QUEUE}"
+    export STUB_SLEEP_HOOK="printf 'usage_usec %s\n' $(( BASE_USEC + 3000000 )) > '${CPU_STAT_FILE}'"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No usable previous CPU sample"* ]]
+    [[ "$output" == *"CPU usage is 100.00% of one core"* ]]
+    assert_metadata 'last-active/cpu'
+}
+
+@test "a restarted container ignores the stale sample from the old container" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v2 4242 "new-container-id" "${BASE_USEC}"
+    # State recorded against a different container id.
+    echo "old-container-id 999999999 ${BEFORE_NSEC}" > "${STATE}/app-cpu-sample"
+    printf '%s\n%s\n' "${BEFORE_NSEC}" "$(( BEFORE_NSEC + 3000000000 ))" > "${CLOCK_QUEUE}"
+    export STUB_SLEEP_HOOK="printf 'usage_usec %s\n' ${BASE_USEC} > '${CPU_STAT_FILE}'"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No usable previous CPU sample"* ]]
+    # An idle container, and no crash from the negative counter difference.
+    refute_metadata 'last-active/cpu'
+}
+
+@test "the current sample is persisted for the next probe run" {
+    export STUB_TARGET_CONTAINER="application-server"
+    local usage=$(( BASE_USEC + 2 * USEC_PER_PERCENT ))
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "${usage}"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ "$(cat "${STATE}/app-cpu-sample")" = "${CONTAINER_ID} ${usage} ${NOW_NSEC}" ]
+}
+
+@test "a sub-second gap between probes is not trusted as a sample" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "$(( BASE_USEC + 100 ))"
+    # Previous sample only 0.5s old: too short to be a meaningful average.
+    echo "${CONTAINER_ID} ${BASE_USEC} ${BEFORE_NSEC}" > "${STATE}/app-cpu-sample"
+    printf '%s\n%s\n' "$(( BEFORE_NSEC + 500000000 ))" "$(( BEFORE_NSEC + 3500000000 ))" > "${CLOCK_QUEUE}"
+    export STUB_SLEEP_HOOK=":"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No usable previous CPU sample"* ]]
+}
+
+@test "ssh activity is still recorded independently of the CPU signal" {
+    export STUB_TARGET_CONTAINER="application-server"
+    export STUB_SSH_ACTIVE="true"
+    # An idle container, so only the ssh signal should fire.
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "${BASE_USEC}"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    refute_metadata 'last-active/cpu'
+    assert_metadata 'last-active/ssh'
+}
+
+@test "proxy activity is still recorded independently of the CPU signal" {
+    export STUB_TARGET_CONTAINER="application-server"
+    given_cgroup_v2 4242 "${CONTAINER_ID}" "${BASE_USEC}"
+    given_previous_sample "${CONTAINER_ID}" "${BASE_USEC}"
+
+    run bash "${SCRIPT}"
+    [ "$status" -eq 0 ]
+    # The proxy container is not running in this fixture, so no proxy signal,
+    # and crucially the CPU change did not disturb the proxy code path.
+    refute_metadata 'last-active/proxy'
+    refute_metadata 'last-active/cpu'
+}


### PR DESCRIPTION
## Problem

`probe-user-access.sh` derives the CPU activity signal from whole-VM load average:

```bash
LOAD="$(awk '{print $3}' /proc/loadavg)"   # 15-min average, entire VM
```

That attributes **any** container's CPU to user activity, not just the application's. A template with
a continuously-busy sidecar keeps the load average above the `0.1` threshold indefinitely, so
`last-active/cpu` is refreshed on every probe, `idle-shutdown.sh` never fires, and the VM runs until
someone notices. On a 4-vCPU VM a sidecar using ~1 core produces a load average around 1.0 — 10x the
threshold.

## Change

CPU activity is now measured from the **application container's own cgroup accounting**
(`cpu.stat`/`usage_usec` on v2, `cpuacct.usage` on v1), diffed against the previous probe's sample.
Container is resolved by name → PID → `/proc/<pid>/cgroup`, which is cgroup-driver agnostic.

- **Target container** — VM metadata key `idle-cpu-container-name`, default `application-server`.
  Metadata (rather than a new positional arg) because the systemd timer that invokes this script lives
  in another repo, and this is already how per-workspace config reaches these scripts
  (`idle-shutdown.sh` reads `idle-timeout-seconds` the same way). Works on both clouds — the AWS
  `metadata-utils.sh` maps the key into the `vwbusr:` tag namespace.
- **Threshold: 5.0% of one core**, deliberately *not* normalized by core count so it means the same
  thing on a 2-vCPU and a 64-vCPU VM (values >100 are expected for multi-core work). Derivation: the
  old `0.1` load average ≈ 10% of one core measured across the whole box; with sidecar and host noise
  now excluded, 5% keeps clear margin over app-server background chatter (ioloop heartbeats, autosave
  — well under 2%) while staying far below real work.
- **`$1` keeps its original meaning** (whole-VM load average) and is used only by the fallback path.
  Reusing it for the new metric would have been a trap: an existing caller passing `0.1` would have
  set a 0.1%-of-a-core threshold and silently preserved the bug.
- **Graceful degradation** — missing container, stopped container, missing cgroup accounting, or a
  stale sample after restart all fall back to the previous load-average behaviour rather than failing.
- `last-active/proxy` and `last-active/ssh` are unchanged.

## Tests

New `tests/test-probe-user-access.bats`, 20 cases, stub-driven with a fake clock, `/proc`, and cgroup
tree: threshold boundary, idle/busy/multi-core, cgroup v1 and v2, missing/stopped container, missing
accounting, restart with stale sample, first-probe sampling, sub-second gap rejection, metadata
override, and assertions that the proxy/ssh signals still behave. Wired into `test-scripts.yaml` with
path filters. shellcheck clean under the repo's CI flags.

The existing `tests/` harness is integration-only (`docker exec` into a live container) so it couldn't
cover this.

Two bugs found while testing: `emit()` wrote to stdout and was being captured into the CPU reading by
command substitution (now stderr); and bare `!` negative assertions in bats silently pass unless
final, so those are wrapped in a helper.

## Reviewers please check

- **The threshold is reasoned, not measured.** 5.0% needs a sanity check against a real idle
  JupyterLab and a light workload before this leaves draft.
- **Regression risk: low-CPU-but-real workloads.** `/proc/loadavg` counts I/O wait, so an I/O-bound or
  GPU-bound job with light CPU used to keep the VM alive. Container CPU accounting does not.
  `last-active/proxy`/`ssh` cover interactive cases but not a detached long-running job. Worth deciding
  whether to also treat container block-I/O (`io.stat`) as an activity signal.
- **AWS metadata cost** — `get_metadata_value` spawns an AWS CLI container per call, so this adds one
  spawn per probe interval (`idle-shutdown.sh` already does this, so there's precedent, but it roughly
  doubles it). I deliberately did not cache: a transient metadata failure returns the *default*,
  indistinguishable from a real read, and caching that would pin the wrong container name for the VM's
  lifetime and reintroduce the never-stops bug.
- **New env seams** (`METADATA_UTILS`, `CGROUP_ROOT`, `PROC_ROOT`, `STATE_DIR`) exist only for fixture
  injection and default to real paths. No other butane script parameterizes
  `/home/core/metadata-utils.sh`, so a second opinion would be welcome.
- **Untested on real hardware** — cgroup path resolution is verified only against fixtures modeled on
  Flatcar's systemd cgroup-v2 layout (`/system.slice/docker-<id>.scope`).