### PR TITLE
Report cache build status before stopping docker

### DIFF
--- a/startupscript/butane/prepare-devcontainer-cache.sh
+++ b/startupscript/butane/prepare-devcontainer-cache.sh
@@ -61,9 +61,7 @@ fi
 
 # Report success before docker is stopped. On AWS set_metadata tags the instance
 # by running the AWS CLI in a container, so it cannot run once the docker daemon
-# is gone. The steps below are covered by errexit and the OnFailure handler, and
-# the cache builder only captures a cache once the instance has also powered
-# itself off, so reporting here cannot turn a failed build into a successful one.
+# is gone.
 # shellcheck source=/dev/null
 source '/home/core/metadata-utils.sh'
 set_metadata 'startup_script/status' "COMPLETED"

--- a/startupscript/butane/prepare-devcontainer-cache.sh
+++ b/startupscript/butane/prepare-devcontainer-cache.sh
@@ -59,6 +59,15 @@ if [[ -n "${DOCKER_DIR+x}" ]]; then
     popd
 fi
 
+# Report success before docker is stopped. On AWS set_metadata tags the instance
+# by running the AWS CLI in a container, so it cannot run once the docker daemon
+# is gone. The steps below are covered by errexit and the OnFailure handler, and
+# the cache builder only captures a cache once the instance has also powered
+# itself off, so reporting here cannot turn a failed build into a successful one.
+# shellcheck source=/dev/null
+source '/home/core/metadata-utils.sh'
+set_metadata 'startup_script/status' "COMPLETED"
+
 # Stop docker and prevent it from starting again
 systemctl mask docker
 systemctl stop docker
@@ -73,10 +82,6 @@ find /var/lib/docker \
     ! -name buildkit \
     ! -name engine-id \
     -exec rm -rf {} +
-
-# shellcheck source=/dev/null
-source '/home/core/metadata-utils.sh'
-set_metadata 'startup_script/status' "COMPLETED"
 
 # Shut down the instance to signal that the image is ready to be saved.
 systemctl poweroff


### PR DESCRIPTION
The cache build reports its final status by calling set_metadata, which on GCP is a curl to the metadata server but on AWS tags the EC2 instance by running the AWS CLI in a container, so it cannot run after this script has masked and stopped the docker daemon.

Move the status write ahead of the docker stop so the AWS cache builder can tell a finished build from one that died, since it reads that status once the instance has powered itself off.

This changes nothing on GCP, where the call never depended on docker.

PHP-151845