### PR TITLE
Use temurin variant of java

### DIFF
--- a/features/src/workbench-tools/install.sh
+++ b/features/src/workbench-tools/install.sh
@@ -20,6 +20,7 @@ readonly USER_HOME_DIR
 
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
+unset PYTHONPATH
 
 WORKDIR="$(mktemp -d)"
 readonly WORKDIR

--- a/src/example/.devcontainer.json
+++ b/src/example/.devcontainer.json
@@ -20,7 +20,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/dhoeric/features/google-cloud-cli:1": {}

--- a/src/jupyter-template/.devcontainer.json
+++ b/src/jupyter-template/.devcontainer.json
@@ -28,7 +28,8 @@
       "username": "jupyter"
     },
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef": {},
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},

--- a/src/nemo_jupyter/.devcontainer.json
+++ b/src/nemo_jupyter/.devcontainer.json
@@ -21,7 +21,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
     "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6": {

--- a/src/nemo_jupyter_aou/.devcontainer.json
+++ b/src/nemo_jupyter_aou/.devcontainer.json
@@ -22,7 +22,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
     "./.devcontainer/features/workbench-tools": {

--- a/src/pgweb/.devcontainer.json
+++ b/src/pgweb/.devcontainer.json
@@ -14,7 +14,8 @@
   "postStartCommand": "/workspace/start-bookmark-refresh.sh",
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef": {}
   },

--- a/src/r-analysis-aou/.devcontainer.json
+++ b/src/r-analysis-aou/.devcontainer.json
@@ -10,7 +10,8 @@
   "postStartCommand": "./startupscript/remount-on-restart.sh rstudio /home/rstudio '${templateOption:cloud}' '${templateOption:login}' && ./setup-rstudio-env.sh rstudio",
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/rocker-org/devcontainer-features/r-packages@sha256:1a4ec64c4d2060e78e9c812bd3b3622c7e008465d566a2781c0e2b17a82592e5": {
       "packages": "shiny,shinydashboard",

--- a/src/r-analysis/.devcontainer.json
+++ b/src/r-analysis/.devcontainer.json
@@ -21,7 +21,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/rocker-org/devcontainer-features/r-packages@sha256:1a4ec64c4d2060e78e9c812bd3b3622c7e008465d566a2781c0e2b17a82592e5": {
       "packages": "shiny,shinydashboard",

--- a/src/ubuntu-example/.devcontainer.json
+++ b/src/ubuntu-example/.devcontainer.json
@@ -20,7 +20,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/dhoeric/features/google-cloud-cli:1": {},

--- a/src/vscode-docker/.devcontainer.json
+++ b/src/vscode-docker/.devcontainer.json
@@ -16,7 +16,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef": {},
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},

--- a/src/vscode-with-llm/.devcontainer.json
+++ b/src/vscode-with-llm/.devcontainer.json
@@ -10,7 +10,8 @@
   "postStartCommand": "./startupscript/remount-on-restart.sh abc /config \"${templateOption:cloud}\" \"${templateOption:login}\"; /opt/llm-context/run-context-generator.sh /config || true",
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6": {
       "version": "24.11.0"

--- a/src/vscode/.devcontainer.json
+++ b/src/vscode/.devcontainer.json
@@ -16,7 +16,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-      "version": "17"
+      "version": "17",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6": {
       "version": "24.11.0"

--- a/src/workbench-jupyter-parabricks-aou/.devcontainer.json
+++ b/src/workbench-jupyter-parabricks-aou/.devcontainer.json
@@ -22,7 +22,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-          "version": "17"
+          "version": "17",
+          "jdkDistro": "tem"
         },
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
     "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef":{},

--- a/src/workbench-jupyter-parabricks/.devcontainer.json
+++ b/src/workbench-jupyter-parabricks/.devcontainer.json
@@ -21,7 +21,8 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-          "version": "17"
+          "version": "17",
+          "jdkDistro": "tem"
         },
     "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
     "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef":{},


### PR DESCRIPTION
Alternative to https://github.com/verily-src/workbench-app-devcontainers/pull/471, temurin doesn't have the same version matching issue as the `ms` distro. Temurin is the recommended version for the CLI anyways, so we should match that