### PR TITLE
Add OpenCode + NVIDIA Nemotron custom app

### DIFF
--- a/src/opencode-nemotron/.devcontainer.json
+++ b/src/opencode-nemotron/.devcontainer.json
@@ -9,11 +9,11 @@
     "postStartCommand":
         "./startupscript/remount-on-restart.sh abc /config \"${templateOption:cloud}\" \"${templateOption:login}\"; ./configure-opencode.sh abc /config; ./start-ollama.sh",
     "features": {
-        "ghcr.io/devcontainers/features/java:1": {
+        "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
             "version": "17"
         },
-        "ghcr.io/devcontainers/features/aws-cli:1": {},
-        "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
+        "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef": {},
+        "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
         "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a": {},
         "./.devcontainer/features/workbench-tools": {
             "cloud": "${templateOption:cloud}",

--- a/src/opencode-nemotron/.devcontainer.json
+++ b/src/opencode-nemotron/.devcontainer.json
@@ -9,9 +9,6 @@
     "postStartCommand":
         "./startupscript/remount-on-restart.sh abc /config \"${templateOption:cloud}\" \"${templateOption:login}\"; ./configure-opencode.sh abc /config; ./start-ollama.sh",
     "features": {
-        "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48": {
-            "version": "17"
-        },
         "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef": {},
         "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f": {},
         "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a": {},

--- a/src/opencode-nemotron/.devcontainer.json
+++ b/src/opencode-nemotron/.devcontainer.json
@@ -1,0 +1,44 @@
+{
+    "name": "OpenCode + NVIDIA Nemotron",
+    "dockerComposeFile": "docker-compose.yaml",
+    "service": "app",
+    "shutdownAction": "none",
+    "workspaceFolder": "/workspace",
+    "postCreateCommand":
+        "./startupscript/post-startup.sh abc /config \"${templateOption:cloud}\" \"${templateOption:login}\"; ./sudo-passwordless.sh abc; ./configure-opencode.sh abc /config; ./start-ollama.sh",
+    "postStartCommand":
+        "./startupscript/remount-on-restart.sh abc /config \"${templateOption:cloud}\" \"${templateOption:login}\"; ./configure-opencode.sh abc /config; ./start-ollama.sh",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "17"
+        },
+        "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
+        "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a": {},
+        "./.devcontainer/features/workbench-tools": {
+            "cloud": "${templateOption:cloud}",
+            "username": "abc",
+            "userHomeDir": "/config"
+        }
+    },
+    "remoteUser": "root",
+    "customizations": {
+        "workbench": {
+            "opens": {
+                "extensions": [
+                    ".py",
+                    ".ipynb",
+                    ".sh",
+                    ".md",
+                    ".html",
+                    ".csv",
+                    ".json",
+                    ".jsonc",
+                    ".yaml",
+                    ".yml"
+                ],
+                "fileUrlSuffix": "?payload=[[\"openFile\",\"vscode-remote:///config/{path}\"]]"
+            }
+        }
+    }
+}

--- a/src/opencode-nemotron/Dockerfile
+++ b/src/opencode-nemotron/Dockerfile
@@ -1,0 +1,34 @@
+FROM lscr.io/linuxserver/code-server@sha256:7bd334657f13505abc1e20afeeee5670ad8f818e68853c810889184e597f3051
+
+ARG OPENCODE_VERSION=1.18.22
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git jq python3 python3-pip python3-venv ripgrep zstd \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /config/extensions /config/.cache \
+    && chown -R abc:abc /config
+
+RUN curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst | tar --zstd -x -C /usr \
+    && ollama --version
+
+# The installer hardcodes its target to ${HOME}/.opencode/bin. /config is a
+# volume mount at run time, so install under /opt and link the binary instead.
+RUN curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh \
+    && HOME=/opt/opencode bash /tmp/install-opencode.sh \
+        --version "${OPENCODE_VERSION}" --no-modify-path \
+    && rm /tmp/install-opencode.sh \
+    && chmod -R a+rX /opt/opencode \
+    && ln -s /opt/opencode/.opencode/bin/opencode /usr/local/bin/opencode \
+    && opencode --version
+
+RUN pip install --break-system-packages openai uv
+
+USER abc
+ENV HOME=/config
+
+RUN /app/code-server/bin/code-server --extensions-dir /config/extensions --install-extension ms-python.python \
+    && mkdir -p /config/data/User \
+    && echo '{"workbench.colorTheme":"Default Dark Modern"}' > /config/data/User/settings.json
+
+USER root
+WORKDIR /config

--- a/src/opencode-nemotron/Dockerfile
+++ b/src/opencode-nemotron/Dockerfile
@@ -13,15 +13,22 @@ RUN curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst | tar --zs
 
 # The installer hardcodes its target to ${HOME}/.opencode/bin. /config is a
 # volume mount at run time, so install under /opt and link the binary instead.
+# The base image sets HOME=/config for every user, including root. Override HOME
+# so neither the installer nor the version check writes root-owned state into
+# /config, which would stop the abc user from starting code-server.
 RUN curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh \
     && HOME=/opt/opencode bash /tmp/install-opencode.sh \
         --version "${OPENCODE_VERSION}" --no-modify-path \
     && rm /tmp/install-opencode.sh \
     && chmod -R a+rX /opt/opencode \
     && ln -s /opt/opencode/.opencode/bin/opencode /usr/local/bin/opencode \
-    && opencode --version
+    && HOME=/opt/opencode opencode --version
 
 RUN pip install --break-system-packages openai uv
+
+# Re-assert ownership after every root layer, in case one of them wrote to
+# /config through the image-wide HOME=/config.
+RUN chown -R abc:abc /config
 
 USER abc
 ENV HOME=/config

--- a/src/opencode-nemotron/Dockerfile
+++ b/src/opencode-nemotron/Dockerfile
@@ -3,7 +3,8 @@ FROM lscr.io/linuxserver/code-server@sha256:7bd334657f13505abc1e20afeeee5670ad8f
 ARG OPENCODE_VERSION=1.18.22
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git jq python3 python3-pip python3-venv ripgrep zstd \
+    && apt-get install -y --no-install-recommends git jq openjdk-17-jre-headless \
+        python3 python3-pip python3-venv ripgrep zstd \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /config/extensions /config/.cache \
     && chown -R abc:abc /config

--- a/src/opencode-nemotron/README.md
+++ b/src/opencode-nemotron/README.md
@@ -51,12 +51,17 @@ print(response.choices[0].message.content)
 
 ## Changing the Model
 
-Set the `model` template option when you create the app. Use any tag from
-https://ollama.com/library. The value must be a tag that Ollama can pull, and the
-model must support tools for `opencode` to work.
+The model tag lives in `OLLAMA_MODEL` in `docker-compose.yaml`. Edit it in your
+fork and point the app config at that branch. Workbench substitutes only a fixed
+set of template options on the VM, so a custom `model` template option would not
+work.
 
-To change the model on a running app, edit `~/.config/opencode/opencode.json` and
-run `ollama pull <tag>`. The app rewrites that file on each restart.
+Use any tag from https://ollama.com/library. The model must support tools, or
+`opencode` cannot call them.
+
+To change the model on a running app, run `ollama pull <tag>` and edit
+`~/.config/opencode/opencode.json`. The app rewrites that file on each restart, so
+the change lasts until the next restart.
 
 ## Configuration
 

--- a/src/opencode-nemotron/README.md
+++ b/src/opencode-nemotron/README.md
@@ -56,17 +56,28 @@ print(message.content)
 
 ## Changing the Model
 
-The model tag lives in `OLLAMA_MODEL` in `docker-compose.yaml`. Edit it in your
-fork and point the app config at that branch. Workbench substitutes only a fixed
-set of template options on the VM, so a custom `model` template option would not
-work.
+Write the tag to `/config/.opencode-model`, then restart the app:
+
+```sh
+echo nemotron-3-nano:4b > /config/.opencode-model
+```
+
+`/config` is a volume, so the override survives a restart and a machine-type
+change. On restart the app pulls the new tag and rewrites
+`~/.config/opencode/opencode.json` to match. Delete the file to return to the
+default.
+
+Pick a model that fits the GPU. See the table above. A model larger than VRAM
+runs partly on the CPU and is very slow. Change the tag before you move an app to
+a smaller GPU, for example from an A100 to an L4.
 
 Use any tag from https://ollama.com/library. The model must support tools, or
 `opencode` cannot call them.
 
-To change the model on a running app, run `ollama pull <tag>` and edit
-`~/.config/opencode/opencode.json`. The app rewrites that file on each restart, so
-the change lasts until the next restart.
+To change the default for new apps, edit `OLLAMA_MODEL` in `docker-compose.yaml`
+in your fork and point the app config at that branch. Workbench substitutes only
+a fixed set of template options on the VM, so a custom `model` template option
+would not work.
 
 ## Configuration
 
@@ -76,6 +87,10 @@ on restart. It sets:
 - `provider.ollama` — an OpenAI-compatible provider at `http://localhost:11434/v1`.
 - `autoupdate: false` — keeps the version that the Dockerfile pins.
 - `share: "disabled"` — blocks the hosted session-sharing service.
+
+`resolve-model.sh` picks the model tag. `/config/.opencode-model` wins, then
+`OLLAMA_MODEL` from `docker-compose.yaml`. Both `configure-opencode.sh` and
+`start-ollama.sh` call it, so the agent and the server always agree.
 
 `OLLAMA_CONTEXT_LENGTH` is set to 32768 in `docker-compose.yaml`. Smaller contexts
 make tool calls unreliable.

--- a/src/opencode-nemotron/README.md
+++ b/src/opencode-nemotron/README.md
@@ -1,0 +1,100 @@
+# OpenCode + NVIDIA Nemotron
+
+Code-server IDE with the [opencode](https://opencode.ai) coding agent wired to a
+local [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron) model.
+[Ollama](https://ollama.com) serves the model inside the container. No prompt,
+code, or data leaves the VM.
+
+- Code-server UI on port 8443.
+- Ollama OpenAI-compatible API on port 11434 (container-local only).
+- `opencode` on the `PATH`, preconfigured to use the local model.
+
+## Recommended VM Configuration
+
+| Model | Weights | GPU | Machine type |
+|---|---|---|---|
+| **`nemotron-3.5-lightning:30b`** | **25 GB** | **A100 40 GB** | **`a2-highgpu-1g`** |
+| `nemotron-3-nano:30b` | 24 GB | A100 40 GB | `a2-highgpu-1g` |
+| `nemotron-3-nano:4b` | 2.8 GB | L4 24 GB | `g2-standard-8` |
+
+`nemotron-3.5-lightning:30b` is the default. It is a 30B mixture-of-experts model
+with 3B active parameters and tool-calling support, which suits an agent loop.
+
+## Usage
+
+1. Open the code-server IDE.
+2. Open a terminal.
+3. Start the agent in a project directory:
+
+    ```sh
+    cd ~/repos/<your-repo>
+    opencode
+    ```
+
+The first run takes a few minutes. The app pulls the model on create and on every
+container restart. A pulled model persists in the `/config` volume.
+
+You can also call the model directly:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:11434/v1", api_key="unused")
+
+response = client.chat.completions.create(
+    model="nemotron-3.5-lightning:30b",
+    messages=[{"role": "user", "content": "Hello!"}],
+    max_tokens=100,
+)
+print(response.choices[0].message.content)
+```
+
+## Changing the Model
+
+Set the `model` template option when you create the app. Use any tag from
+https://ollama.com/library. The value must be a tag that Ollama can pull, and the
+model must support tools for `opencode` to work.
+
+To change the model on a running app, edit `~/.config/opencode/opencode.json` and
+run `ollama pull <tag>`. The app rewrites that file on each restart.
+
+## Configuration
+
+`configure-opencode.sh` writes `~/.config/opencode/opencode.json` on create and
+on restart. It sets:
+
+- `provider.ollama` — an OpenAI-compatible provider at `http://localhost:11434/v1`.
+- `autoupdate: false` — keeps the version that the Dockerfile pins.
+- `share: "disabled"` — blocks the hosted session-sharing service.
+
+`OLLAMA_CONTEXT_LENGTH` is set to 32768 in `docker-compose.yaml`. Smaller contexts
+make tool calls unreliable.
+
+## Debugging
+
+Check the Ollama server log:
+
+```sh
+tail -f ~/ollama-server.log
+```
+
+Verify that the server answers and the model is present:
+
+```sh
+curl http://localhost:11434/v1/models
+ollama list
+```
+
+Confirm that the GPU is in use. `ollama ps` reports `100% GPU` when the model fits
+in VRAM:
+
+```sh
+nvidia-smi
+ollama ps
+```
+
+Print the resolved opencode config:
+
+```sh
+opencode models
+```

--- a/src/opencode-nemotron/README.md
+++ b/src/opencode-nemotron/README.md
@@ -44,9 +44,14 @@ client = OpenAI(base_url="http://localhost:11434/v1", api_key="unused")
 response = client.chat.completions.create(
     model="nemotron-3.5-lightning:30b",
     messages=[{"role": "user", "content": "Hello!"}],
-    max_tokens=100,
 )
-print(response.choices[0].message.content)
+
+# Nemotron reasons before it answers. Ollama returns the thinking tokens in a
+# non-standard `reasoning` field, so a small max_tokens truncates the reply
+# before `content` holds anything.
+message = response.choices[0].message
+print(getattr(message, "reasoning", ""))
+print(message.content)
 ```
 
 ## Changing the Model

--- a/src/opencode-nemotron/configure-opencode.sh
+++ b/src/opencode-nemotron/configure-opencode.sh
@@ -15,7 +15,9 @@ if [[ -z "${USER_NAME}" || -z "${USER_HOME_DIR}" ]]; then
   exit 1
 fi
 
-readonly MODEL="${OLLAMA_MODEL:-nemotron-3.5-lightning:30b}"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+MODEL="$("${SCRIPT_DIR}/resolve-model.sh")"
+readonly SCRIPT_DIR MODEL
 readonly CONFIG_DIR="${USER_HOME_DIR}/.config/opencode"
 readonly CONFIG_FILE="${CONFIG_DIR}/opencode.json"
 

--- a/src/opencode-nemotron/configure-opencode.sh
+++ b/src/opencode-nemotron/configure-opencode.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Writes the opencode global config so the agent talks to the local Ollama
+# server instead of a hosted provider. Called from post-startup and on restart.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+USER_NAME="${1:-}"
+USER_HOME_DIR="${2:-}"
+
+if [[ -z "${USER_NAME}" || -z "${USER_HOME_DIR}" ]]; then
+  echo "Usage: $0 <username> <user-home-dir>"
+  exit 1
+fi
+
+readonly MODEL="${OLLAMA_MODEL:-nemotron-3.5-lightning:30b}"
+readonly CONFIG_DIR="${USER_HOME_DIR}/.config/opencode"
+readonly CONFIG_FILE="${CONFIG_DIR}/opencode.json"
+
+mkdir -p "${CONFIG_DIR}"
+
+# share=disabled keeps prompts and code off opencode's hosted sharing service.
+# autoupdate=false keeps the version pinned by the Dockerfile.
+jq -n --arg model "${MODEL}" '{
+  "$schema": "https://opencode.ai/config.json",
+  "model": ("ollama/" + $model),
+  "small_model": ("ollama/" + $model),
+  "autoupdate": false,
+  "share": "disabled",
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": { "baseURL": "http://localhost:11434/v1" },
+      "models": { ($model): { "name": $model } }
+    }
+  }
+}' > "${CONFIG_FILE}"
+
+chown -R "${USER_NAME}:${USER_NAME}" "${USER_HOME_DIR}/.config"
+
+echo "Wrote opencode config for ${MODEL} to ${CONFIG_FILE}"

--- a/src/opencode-nemotron/devcontainer-template.json
+++ b/src/opencode-nemotron/devcontainer-template.json
@@ -22,16 +22,6 @@
                 "false"
             ],
             "default": "false"
-        },
-        "model": {
-            "type": "string",
-            "description": "Ollama model tag that opencode uses",
-            "proposals": [
-                "nemotron-3.5-lightning:30b",
-                "nemotron-3-nano:30b",
-                "nemotron-3-nano:4b"
-            ],
-            "default": "nemotron-3.5-lightning:30b"
         }
     },
     "platforms": [

--- a/src/opencode-nemotron/devcontainer-template.json
+++ b/src/opencode-nemotron/devcontainer-template.json
@@ -1,0 +1,40 @@
+{
+    "id": "opencode-nemotron",
+    "version": "0.0.1",
+    "name": "OpenCode + NVIDIA Nemotron",
+    "description": "Code-server IDE with the opencode coding agent driving a local NVIDIA Nemotron model on Ollama. Requires an NVIDIA GPU with at least 40 GB of VRAM.",
+    "documentationURL": "https://github.com/verily-src/workbench-app-devcontainers/tree/master/src/opencode-nemotron",
+    "licenseURL": "https://github.com/verily-src/workbench-app-devcontainers/blob/master/LICENSE",
+    "options": {
+        "cloud": {
+            "type": "string",
+            "description": "VM cloud environment",
+            "proposals": [
+                "gcp"
+            ],
+            "default": "gcp"
+        },
+        "login": {
+            "type": "string",
+            "description": "Whether to log in to workbench CLI",
+            "proposals": [
+                "true",
+                "false"
+            ],
+            "default": "false"
+        },
+        "model": {
+            "type": "string",
+            "description": "Ollama model tag that opencode uses",
+            "proposals": [
+                "nemotron-3.5-lightning:30b",
+                "nemotron-3-nano:30b",
+                "nemotron-3-nano:4b"
+            ],
+            "default": "nemotron-3.5-lightning:30b"
+        }
+    },
+    "platforms": [
+        "Any"
+    ]
+}

--- a/src/opencode-nemotron/docker-compose.yaml
+++ b/src/opencode-nemotron/docker-compose.yaml
@@ -1,0 +1,35 @@
+services:
+  app:
+    container_name: "application-server"
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    volumes:
+      - .:/workspace:cached
+      - work:/config:cached
+    ports:
+      - "8443:8443"
+    environment:
+      USER: "abc"
+      DEFAULT_WORKSPACE: "/config"
+      SUDO_PASSWORD: "pwd"
+      OLLAMA_MODEL: "${templateOption:model}"
+      OLLAMA_KEEP_ALIVE: "-1"
+      OLLAMA_FLASH_ATTENTION: "true"
+      # opencode needs a large context for reliable tool calls.
+      OLLAMA_CONTEXT_LENGTH: "32768"
+    networks:
+      - app-network
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
+
+networks:
+  app-network:
+    external: true
+volumes:
+  work:

--- a/src/opencode-nemotron/docker-compose.yaml
+++ b/src/opencode-nemotron/docker-compose.yaml
@@ -14,7 +14,10 @@ services:
       USER: "abc"
       DEFAULT_WORKSPACE: "/config"
       SUDO_PASSWORD: "pwd"
-      OLLAMA_MODEL: "${templateOption:model}"
+      # Workbench only substitutes a fixed set of template options on the VM
+      # (see startupscript/butane/050-parse-devcontainer.sh), so the model tag
+      # is set here rather than as a template option.
+      OLLAMA_MODEL: "nemotron-3.5-lightning:30b"
       OLLAMA_KEEP_ALIVE: "-1"
       OLLAMA_FLASH_ATTENTION: "true"
       # opencode needs a large context for reliable tool calls.

--- a/src/opencode-nemotron/resolve-model.sh
+++ b/src/opencode-nemotron/resolve-model.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Prints the Ollama model tag that the app must use.
+#
+# Workbench substitutes only a fixed set of template options on the VM, so the
+# tag cannot be a template option. An operator overrides the docker-compose
+# default by writing a tag to /config/.opencode-model. /config is a volume, so
+# the override survives a restart and a machine-type change. Example: a move
+# from an A100 to an L4 needs a model that fits in less VRAM.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly MODEL_OVERRIDE_FILE="/config/.opencode-model"
+readonly DEFAULT_MODEL="nemotron-3.5-lightning:30b"
+
+if [[ -s "${MODEL_OVERRIDE_FILE}" ]]; then
+  tr -d '[:space:]' < "${MODEL_OVERRIDE_FILE}"
+else
+  echo "${OLLAMA_MODEL:-${DEFAULT_MODEL}}"
+fi

--- a/src/opencode-nemotron/start-ollama.sh
+++ b/src/opencode-nemotron/start-ollama.sh
@@ -6,7 +6,9 @@ set -o pipefail
 
 readonly OLLAMA_LOG="/config/ollama-server.log"
 readonly OLLAMA_URL="http://localhost:11434"
-readonly MODEL="${OLLAMA_MODEL:-nemotron-3.5-lightning:30b}"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+MODEL="$("${SCRIPT_DIR}/resolve-model.sh")"
+readonly SCRIPT_DIR MODEL
 
 server_is_up() {
   curl -fsS "${OLLAMA_URL}/api/version" > /dev/null 2>&1

--- a/src/opencode-nemotron/start-ollama.sh
+++ b/src/opencode-nemotron/start-ollama.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly OLLAMA_LOG="/config/ollama-server.log"
+readonly OLLAMA_URL="http://localhost:11434"
+readonly MODEL="${OLLAMA_MODEL:-nemotron-3.5-lightning:30b}"
+
+server_is_up() {
+  curl -fsS "${OLLAMA_URL}/api/version" > /dev/null 2>&1
+}
+
+# postCreateCommand and postStartCommand both run on first start, so only start
+# the server if it is not already listening.
+if ! server_is_up; then
+  nohup ollama serve > "${OLLAMA_LOG}" 2>&1 &
+
+  for _ in $(seq 30); do
+    if server_is_up; then
+      break
+    fi
+    sleep 2
+  done
+
+  if ! server_is_up; then
+    echo "Ollama did not start — see ${OLLAMA_LOG}" >&2
+    exit 1
+  fi
+fi
+
+echo "Pulling ${MODEL} (this may take several minutes)..."
+ollama pull "${MODEL}" >> "${OLLAMA_LOG}" 2>&1
+
+echo "Preloading ${MODEL} into GPU memory..."
+curl -fsS "${OLLAMA_URL}/api/generate" \
+  -d "{\"model\":\"${MODEL}\",\"prompt\":\"warmup\",\"options\":{\"num_predict\":1}}" > /dev/null
+
+echo "Ollama ready with ${MODEL} — logs at ${OLLAMA_LOG}"

--- a/src/opencode-nemotron/sudo-passwordless.sh
+++ b/src/opencode-nemotron/sudo-passwordless.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script is used to set up passwordless sudo for the core user on the VM.
+# It requires to be run with root priviledges and USER_NAME to be set in the environment.
+# It is typically called from post-startup.sh.
+
+USER_NAME="${1}"
+
+if [[ -z "${USER_NAME}" ]]; then
+  echo "Usage: $0 <username>"
+  exit 1
+fi
+
+sudoers_file="/etc/sudoers"
+sudoers_d_file="/etc/sudoers.d/${USER_NAME}"
+
+# Make sure user exists
+if ! id "${USER_NAME}" &>/dev/null; then
+  echo "User ${USER_NAME} does not exist."
+  exit 1
+fi
+
+# Check if there's an old rule in the main sudoers file that requires a password
+if grep -q "^${USER_NAME} ALL=(ALL:ALL) ALL" "${sudoers_file}"; then
+  echo "Found password-requiring rule for ${USER_NAME} in /etc/sudoers. Commenting it out."
+
+  # Comment out the old rule in /etc/sudoers
+  sed -i "s/^${USER_NAME} ALL=(ALL:ALL) ALL/# ${USER_NAME} ALL=(ALL:ALL) ALL/" "${sudoers_file}"
+fi
+
+echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" > "${sudoers_d_file}"
+chmod 440 "${sudoers_d_file}"
+
+echo "User ${USER_NAME} has been given passwordless sudo access."


### PR DESCRIPTION
Adds `src/opencode-nemotron`: code-server with the [opencode](https://opencode.ai) agent driving a local NVIDIA Nemotron model on Ollama. Nothing leaves the VM. For the NVIDIA dev day demo. Derived from `feature/applegath/ollama_gemma-4-26B-A4B`.

This PR:
* Serves code-server on 8443 and Ollama on 11434 (container-local). Pins `opencode` 1.18.22.
* Defaults to `nemotron-3.5-lightning:30b` — 30B MoE, tool calling, 25 GB of weights. Needs an A100 40 GB.
* Resolves the model tag in `resolve-model.sh`: `/config/.opencode-model` first, then `OLLAMA_MODEL` from `docker-compose.yaml`. Both `start-ollama.sh` and `configure-opencode.sh` call it, so the server and the agent config cannot drift.
* Writes `~/.config/opencode/opencode.json` on create and restart, with `share: "disabled"` so sessions never reach opencode's hosted sharing service.
* Sets `OLLAMA_CONTEXT_LENGTH=32768`. Tool calls are unreliable below ~16k.

Two deviations worth review:

* **The model tag is not a template option.** The VM substitutes only `login`, `cloud`, `containerImage`, `containerPort`, `shmSize`, and `memoryLimit` (`startupscript/butane/050-parse-devcontainer.sh`). A custom option stays literal and breaks `docker-compose config`. So the default lives in `OLLAMA_MODEL` in `docker-compose.yaml`. To change the model on an existing app, write the tag to `/config/.opencode-model` and restart. `/config` is a volume, so the override survives a restart and a machine-type change. An A100 to L4 move needs a smaller model, and this is how you make that change.
* **OpenJDK 17 comes from apt, not `ghcr.io/devcontainers/features/java`.** That feature is currently broken for all 13 apps that use it, including `vscode-with-llm` and `nemo_jupyter`: Microsoft's Java 17 SDKMAN identifier is now `17.0.20+1-ms`, and the feature's regex rejects the `+1` segment. Upstream: devcontainers/features#1712, fix in #1713. Pinning the digest does not help — the lookup is against SDKMAN's live catalog. The other apps need a separate ticket. This app stays unaffected by the upstream outcome either way; `install-java.sh` only needs `/usr/bin/java`.

## Testing

Deployed to `samh-sandbox` on `a2-highgpu-1g` (1x A100 40 GB, us-central1-c):

* `ollama ps` → `nemotron-3.5-lightning:30b`, 25 GB, **100% GPU**, context 32768.
* `opencode run "Read hello.txt and tell me exactly how many lines it has"` → agent called its read tool and answered correctly.
* `java` 17.0.19 and `wb` on the `PATH`, so `post-startup.sh` succeeds. code-server answers on 8443.
* Model override → `resolve-model.sh` returns `nemotron-3.5-lightning:30b` by default and `nemotron-3-nano:4b` with `/config/.opencode-model` present. `configure-opencode.sh` then writes `ollama/nemotron-3-nano:4b`. Deleting the file reverts to the default. The `abc` user can write `/config` directly, so the documented command needs no `sudo`.
* Direct API example → with `max_tokens=100` the reply stops at `finish_reason=length` and `content` is empty. With no cap, `finish_reason=stop` and `content` is `'Hello! How can I help you today?'`. Nemotron always returns its thinking in Ollama's non-standard `reasoning` field, so the README prints both.

Not tested: `ollama pull` of a changed tag on restart. That path is a single line and reads the verified resolver.

Not registered in `test-pr.yaml`: CI runs `devcontainer up`, which would pull 25 GB on a GPU-less runner.

BENCH-9850
