### PR TITLE
Upgrade pgweb to a non-EOL debian image

### DIFF
--- a/feature-versions/state.json
+++ b/feature-versions/state.json
@@ -84,6 +84,11 @@
     "installed": "sha256:a5256d416e2e8b92d69a4459058e3eca33a9f075d8325491644411d0bc3bd70b",
     "filter": "src\\/.*\\/Dockerfile"
   },
+  "debian": {
+    "tag": "12.15-slim",
+    "installed": "sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171",
+    "filter": "src\\/pgweb\\/Dockerfile"
+  },
   "mikefarah/yq": {
     "tag": "4",
     "installed": "sha256:cfc4eee658595834ef304eadb0c3ea721f3b7cb6404ad8b7cb909cc5b5145b23",

--- a/feature-versions/state.json
+++ b/feature-versions/state.json
@@ -85,8 +85,8 @@
     "filter": "src\\/.*\\/Dockerfile"
   },
   "debian": {
-    "tag": "12.15-slim",
-    "installed": "sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171",
+    "tag": "13.6-slim",
+    "installed": "sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132",
     "filter": "src\\/pgweb\\/Dockerfile"
   },
   "mikefarah/yq": {

--- a/src/pgweb/Dockerfile
+++ b/src/pgweb/Dockerfile
@@ -4,11 +4,25 @@ FROM sosedoff/pgweb@sha256:a5256d416e2e8b92d69a4459058e3eca33a9f075d832549164441
 # ourselves so we can pin/update the base OS independently of upstream.
 # TODO: remove this workaround once sosedoff/pgweb publishes an image with
 # an up-to-date OS and we can go back to using it directly.
-FROM debian@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
+FROM debian@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132 AS keyring
+ADD https://www.postgresql.org/media/keys/ACCC4CF8.asc keyring.asc
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends gpg
+RUN gpg -o keyring.pgp --dearmor keyring.asc
+
+FROM debian@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 
 USER root
 
-RUN apt-get update && \
+ARG keyring=/usr/share/keyrings/postgresql-archive-keyring.pgp
+COPY --from=keyring /keyring.pgp $keyring
+
+# Use the official postgresql.org apt repo (rather than Debian's bundled
+# packages) so we get a current postgresql-client, matching upstream:
+# https://github.com/sosedoff/pgweb/blob/master/Dockerfile
+RUN . /etc/os-release && \
+    echo "deb [signed-by=${keyring}] http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
     apt-get -y install --no-install-recommends \
         ca-certificates \
         curl \

--- a/src/pgweb/Dockerfile
+++ b/src/pgweb/Dockerfile
@@ -1,12 +1,31 @@
-FROM sosedoff/pgweb@sha256:a5256d416e2e8b92d69a4459058e3eca33a9f075d8325491644411d0bc3bd70b
+FROM sosedoff/pgweb@sha256:a5256d416e2e8b92d69a4459058e3eca33a9f075d8325491644411d0bc3bd70b AS pgweb
+
+# We extract just the pgweb binary and rebuild the rest of this Dockerfile
+# ourselves so we can pin/update the base OS independently of upstream.
+# TODO: remove this workaround once sosedoff/pgweb publishes an image with
+# an up-to-date OS and we can go back to using it directly.
+FROM debian@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 
 USER root
 
 RUN apt-get update && \
-    apt-get -y install sudo && \
+    apt-get -y install --no-install-recommends \
+        ca-certificates \
+        curl \
+        netcat-openbsd \
+        openssl \
+        postgresql-client \
+        sudo && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* && \
+    useradd --uid 1000 --no-create-home --shell /bin/false pgweb && \
     mkdir -p /pgweb && \
     chown pgweb:pgweb /pgweb
 
+COPY --from=pgweb /usr/bin/pgweb /usr/bin/pgweb
+
 USER pgweb
+
+EXPOSE 8081
+
+ENTRYPOINT ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]


### PR DESCRIPTION
Wiz scan failing because debian 11 is EOL. The pgweb docker image is still on debian 11. Build the image using debian 12 and extract pgweb into it.