### PR TITLE
Point private-ecr-jupyter devcontainer at dev-unstable account

### DIFF
--- a/src/private-ecr-jupyter/README.md
+++ b/src/private-ecr-jupyter/README.md
@@ -1,7 +1,7 @@
 
 # Private ECR Jupyter
 
-A devcontainer pointing to a private ECR repo in the Workbench `dev` AWS account.
+A devcontainer pointing to a private ECR repo in the Workbench `dev-unstable` AWS account.
 Used for UI automated integration testing.
 
-See [source](https://us-east-1.console.aws.amazon.com/ecr/repositories/private/639879951631/verily-workbench-private-test-app-repo?region=us-east-1).
+See [source](https://us-east-1.console.aws.amazon.com/ecr/repositories/private/677276073900/verily-workbench-private-test-app-repo?region=us-east-1).

--- a/src/private-ecr-jupyter/docker-compose.yaml
+++ b/src/private-ecr-jupyter/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2.4"
 services:
   app:
     container_name: "application-server"
-    image: "639879951631.dkr.ecr.us-east-1.amazonaws.com/verily-workbench-private-test-app-repo:latest"
+    image: "677276073900.dkr.ecr.us-east-1.amazonaws.com/verily-workbench-private-test-app-repo:latest"
     restart: always
     volumes:
       - .:/workspace:cached


### PR DESCRIPTION
## Summary
Point the `private-ecr-jupyter` devcontainer at the correct AWS account for the external ECR test repo (`verily-workbench-private-test-app-repo`), since the previous account is being decommissioned.

## Test plan
- [x] Verified with a Workbench e2e run: the app builds, starts, and is deleted successfully against the new account.