### PR TITLE
Repoint devcontainer base images to user-apps-artifacts

### DIFF
--- a/feature-versions/state.json
+++ b/feature-versions/state.json
@@ -34,24 +34,24 @@
     "installed": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
     "filter": "src\\/.*\\/\\.devcontainer\\.json"
   },
-  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-wondershaper": {
+  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-wondershaper": {
     "tag": "latest",
-    "installed": "sha256:89beaf5d77a2602470e0cf8f388edfa07b75d60f7aa39d05c6a9f960bb3f15d5",
+    "installed": "sha256:3e9ebb173fa8bd160080bf207f39a1a3ec807ea942376c9cee7e0eae6c5ba4ab",
     "filter": "src\\/.*\\/docker-compose.yaml"
   },
-  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-jupyter-extension-builder": {
+  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-jupyter-extension-builder": {
     "tag": "latest",
-    "installed": "sha256:6e5650bb9c478afdd926dc90879fd7ff789533ff9583260e9afa92819020d42d",
+    "installed": "sha256:e0954df8685d73872af044db0fbf73e8e1f68a0325a24918e0f81631fe69aaf7",
     "filter": "src\\/.*\\/Dockerfile"
   },
-  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-aou-jupyter": {
+  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-aou-jupyter": {
     "tag": "latest",
-    "installed": "sha256:77a3d3d1f8f28f25cd9cd2d2fe34987e490d815921365672e897e408f807c398",
+    "installed": "sha256:4283c7dd4d147f9847f01863b09be7e2ceb152c6d86f18264f3a97349b63f56f",
     "filter": "src\\/.*\\/Dockerfile"
   },
-  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-workbench-jupyter": {
+  "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-workbench-jupyter": {
     "tag": "latest",
-    "installed": "sha256:6960bfaf61679dcd3098a588214d559c7d3b1edd4cc90efcc98a63af0b90a9b3",
+    "installed": "sha256:8c529bc65213a832750b0bf8bf3cd6d07645eb9e5f0ea9e49b023d7608a34ed8",
     "filter": "src\\/.*\\/Dockerfile"
   },
   "ghcr.io/rocker-org/devcontainer/tidyverse": {

--- a/src/aou-common/extension-builder/Dockerfile
+++ b/src/aou-common/extension-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-jupyter-extension-builder@sha256:6e5650bb9c478afdd926dc90879fd7ff789533ff9583260e9afa92819020d42d
+FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-jupyter-extension-builder@sha256:e0954df8685d73872af044db0fbf73e8e1f68a0325a24918e0f81631fe69aaf7
 
 COPY extension /extension
 

--- a/src/aou-sas/docker-compose.yaml
+++ b/src/aou-sas/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - apparmor:unconfined
   wondershaper:
     container_name: "wondershaper"
-    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-wondershaper@sha256:0438761b165f6f8da90383722278be8cf89607f39cd42c386877fe72f26b3b40"
+    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-wondershaper@sha256:3e9ebb173fa8bd160080bf207f39a1a3ec807ea942376c9cee7e0eae6c5ba4ab"
     restart: always
     network_mode: "host"
     cap_add:

--- a/src/custom-workbench-jupyter-template/Dockerfile
+++ b/src/custom-workbench-jupyter-template/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-workbench-jupyter@sha256:6960bfaf61679dcd3098a588214d559c7d3b1edd4cc90efcc98a63af0b90a9b3 
+FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-workbench-jupyter@sha256:8c529bc65213a832750b0bf8bf3cd6d07645eb9e5f0ea9e49b023d7608a34ed8 
 
 # Install jupyter extensions
 RUN --mount=type=bind,from=jupyter-extension-builder,source=/dist,target=/tmp/extensions \

--- a/src/jupyter-aou/Dockerfile
+++ b/src/jupyter-aou/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-aou-jupyter@sha256:77a3d3d1f8f28f25cd9cd2d2fe34987e490d815921365672e897e408f807c398
+FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-aou-jupyter@sha256:4283c7dd4d147f9847f01863b09be7e2ceb152c6d86f18264f3a97349b63f56f
 
 # Install jupyter extensions
 RUN --mount=type=bind,from=jupyter-extension-builder,source=/dist,target=/tmp/extensions \

--- a/src/jupyter-aou/docker-compose.yaml
+++ b/src/jupyter-aou/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     # TODO(PHP-87353): Add remotefuse back. See https://github.com/verily-src/workbench-app-devcontainers/pull/227
   wondershaper:
     container_name: "wondershaper"
-    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-wondershaper@sha256:89beaf5d77a2602470e0cf8f388edfa07b75d60f7aa39d05c6a9f960bb3f15d5"
+    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-wondershaper@sha256:3e9ebb173fa8bd160080bf207f39a1a3ec807ea942376c9cee7e0eae6c5ba4ab"
     restart: always
     network_mode: "host"
     cap_add:

--- a/src/jupyter-common/extension-builder/Dockerfile
+++ b/src/jupyter-common/extension-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-jupyter-extension-builder@sha256:6e5650bb9c478afdd926dc90879fd7ff789533ff9583260e9afa92819020d42d
+FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-jupyter-extension-builder@sha256:e0954df8685d73872af044db0fbf73e8e1f68a0325a24918e0f81631fe69aaf7
 
 COPY extension /extension
 

--- a/src/nemo_jupyter_aou/docker-compose.yaml
+++ b/src/nemo_jupyter_aou/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     command: jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --LabApp.token=''
   wondershaper:
     container_name: "wondershaper"
-    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-wondershaper@sha256:89beaf5d77a2602470e0cf8f388edfa07b75d60f7aa39d05c6a9f960bb3f15d5"
+    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-wondershaper@sha256:3e9ebb173fa8bd160080bf207f39a1a3ec807ea942376c9cee7e0eae6c5ba4ab"
     restart: always
     network_mode: "host"
     cap_add:

--- a/src/r-analysis-aou/docker-compose.yaml
+++ b/src/r-analysis-aou/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - apparmor:unconfined
   wondershaper:
     container_name: "wondershaper"
-    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-wondershaper@sha256:89beaf5d77a2602470e0cf8f388edfa07b75d60f7aa39d05c6a9f960bb3f15d5"
+    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-wondershaper@sha256:3e9ebb173fa8bd160080bf207f39a1a3ec807ea942376c9cee7e0eae6c5ba4ab"
     restart: always
     network_mode: "host"
     cap_add:

--- a/src/virtual-browser-jupyter/Dockerfile
+++ b/src/virtual-browser-jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-workbench-jupyter@sha256:7e32fa4c82d9ec5381b81e2673ff9e15f8eed0b767e3a83bb4a2d84714dbe4eb 
+FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-workbench-jupyter@sha256:8c529bc65213a832750b0bf8bf3cd6d07645eb9e5f0ea9e49b023d7608a34ed8 
 
 # Install jupyter extensions
 RUN --mount=type=bind,from=jupyter-extension-builder,source=/dist,target=/tmp/extensions \

--- a/src/workbench-jupyter-parabricks-aou/docker-compose.yaml
+++ b/src/workbench-jupyter-parabricks-aou/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     command: ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--LabApp.token=''"]
   wondershaper:
     container_name: "wondershaper"
-    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-wondershaper@sha256:89beaf5d77a2602470e0cf8f388edfa07b75d60f7aa39d05c6a9f960bb3f15d5"
+    image: "us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-wondershaper@sha256:3e9ebb173fa8bd160080bf207f39a1a3ec807ea942376c9cee7e0eae6c5ba4ab"
     restart: always
     network_mode: "host"
     cap_add:

--- a/src/workbench-jupyter-with-llm/Dockerfile
+++ b/src/workbench-jupyter-with-llm/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/workbench-artifacts/app-workbench-jupyter@sha256:6960bfaf61679dcd3098a588214d559c7d3b1edd4cc90efcc98a63af0b90a9b3 
+FROM us-west2-docker.pkg.dev/shared-pub-buckets-94mvrf/user-apps-artifacts/app-workbench-jupyter@sha256:8c529bc65213a832750b0bf8bf3cd6d07645eb9e5f0ea9e49b023d7608a34ed8 
 
 # Install jupyter extensions
 RUN --mount=type=bind,from=jupyter-extension-builder,source=/dist,target=/tmp/extensions \


### PR DESCRIPTION
The internal service that used to publish these four base images (app-wondershaper, app-jupyter-extension-builder, app-aou-jupyter, app-workbench-jupyter) under the `workbench-artifacts` registry path is being decommissioned. This repoints every pinned digest in `feature-versions/state.json`, the `docker-compose.yaml` files, and the `Dockerfile`s to the current `latest` build already published under `user-apps-artifacts`.

This is a **draft** — please hold on merging until the new publishing pipeline is confirmed stable.